### PR TITLE
[codex] Gracefully handle Graph permission, missing-resource, and throttling failures

### DIFF
--- a/Private/Convert-GraphEssentialsAppToReportObject.ps1
+++ b/Private/Convert-GraphEssentialsAppToReportObject.ps1
@@ -74,8 +74,12 @@ function Convert-GraphEssentialsAppToReportObject {
                     }
                 }
             } catch {
-                Write-Warning "Convert-GraphEssentialsAppToReportObject: Failed to get owners for Application $ApplicationObjectId. Error: $($_.Exception.Message)"
-                $appOwnersRawList.Add([PSCustomObject]@{ Error = "Error fetching app owners: $($_.Exception.Message)" }) # Add to list
+                $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Convert-GraphEssentialsAppToReportObject'
+                if ($errorInfo.IsNotFound) {
+                    Write-Verbose "Convert-GraphEssentialsAppToReportObject: Application owner references for $ApplicationObjectId could not be resolved."
+                } else {
+                    Write-Warning $errorInfo.FullMessage
+                }
             }
         }
 

--- a/Private/Get-AuthMethodConfig.ps1
+++ b/Private/Get-AuthMethodConfig.ps1
@@ -9,7 +9,12 @@
         $Config = Get-MgPolicyAuthenticationMethodPolicyAuthenticationMethodConfiguration -AuthenticationMethodConfigurationId $ConfigId -ErrorAction Stop
         return $Config
     } catch {
-        Write-Warning -Message "Get-MyAuthenticationMethodsPolicy - Failed to get configuration for $MethodName. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyAuthenticationMethodsPolicy'
+        if ($errorInfo.IsNotFound) {
+            Write-Verbose -Message "Get-MyAuthenticationMethodsPolicy - Configuration for $MethodName is not available in this tenant."
+        } else {
+            Write-Warning -Message $errorInfo.FullMessage
+        }
         return $null
     }
 }

--- a/Private/Get-GitHubVersion.ps1
+++ b/Private/Get-GitHubVersion.ps1
@@ -7,17 +7,22 @@
     )
     $App = Get-Command -Name $Cmdlet -ErrorAction SilentlyContinue
     if ($App) {
-        [Array] $GitHubReleases = (Get-GitHubLatestRelease -Url "https://api.github.com/repos/$RepositoryOwner/$RepositoryName/releases" -Verbose:$false)
-        $LatestVersion = $GitHubReleases[0]
-        if (-not $LatestVersion.Errors) {
-            if ($App.Version -eq $LatestVersion.Version) {
-                "Current/Latest: $($LatestVersion.Version) at $($LatestVersion.PublishDate)"
-            } elseif ($App.Version -lt $LatestVersion.Version) {
-                "Current: $($App.Version), Published: $($LatestVersion.Version) at $($LatestVersion.PublishDate). Update?"
-            } elseif ($App.Version -gt $LatestVersion.Version) {
-                "Current: $($App.Version), Published: $($LatestVersion.Version) at $($LatestVersion.PublishDate). Lucky you!"
+        try {
+            [Array] $GitHubReleases = (Get-GitHubLatestRelease -Url "https://api.github.com/repos/$RepositoryOwner/$RepositoryName/releases" -Verbose:$false)
+            $LatestVersion = $GitHubReleases[0]
+            if (-not $LatestVersion.Errors) {
+                if ($App.Version -eq $LatestVersion.Version) {
+                    "Current/Latest: $($LatestVersion.Version) at $($LatestVersion.PublishDate)"
+                } elseif ($App.Version -lt $LatestVersion.Version) {
+                    "Current: $($App.Version), Published: $($LatestVersion.Version) at $($LatestVersion.PublishDate). Update?"
+                } elseif ($App.Version -gt $LatestVersion.Version) {
+                    "Current: $($App.Version), Published: $($LatestVersion.Version) at $($LatestVersion.PublishDate). Lucky you!"
+                }
+            } else {
+                "Current: $($App.Version)"
             }
-        } else {
+        } catch {
+            Write-Verbose -Message "Get-GitHubVersion - Failed to query GitHub releases. Falling back to local version only. Error: $($_.Exception.Message)"
             "Current: $($App.Version)"
         }
     }

--- a/Private/Get-GraphEssentialsAppOwners.ps1
+++ b/Private/Get-GraphEssentialsAppOwners.ps1
@@ -29,8 +29,12 @@ function Get-GraphEssentialsAppOwners {
             Write-Verbose "Get-GraphEssentialsAppOwners: No owners found for Service Principal $ServicePrincipalObjectId."
         }
     } catch {
-        Write-Warning "Get-GraphEssentialsAppOwners: Failed to get owners for SP $ServicePrincipalObjectId. Error: $($_.Exception.Message)"
-        $OwnersInfo.Add([PSCustomObject]@{ Error = "Error fetching SP owners: $($_.Exception.Message)" })
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-GraphEssentialsAppOwners'
+        if ($errorInfo.IsNotFound) {
+            Write-Verbose "Get-GraphEssentialsAppOwners: Service Principal $ServicePrincipalObjectId no longer resolves while fetching owners."
+        } else {
+            Write-Warning $errorInfo.FullMessage
+        }
     }
     $OwnersInfo
 }

--- a/Private/Get-GraphEssentialsErrorDetails.ps1
+++ b/Private/Get-GraphEssentialsErrorDetails.ps1
@@ -102,6 +102,16 @@ function Get-GraphEssentialsErrorDetails {
             $errorDetails.FullMessage = "$($FunctionName): $($ErrorRecord.Exception.Message)"
         }
 
+        if (($errorDetails.Code -eq 'Unknown' -or $errorDetails.Code -eq 'UnknownError') -and
+            $exceptionText -match '"errorCode"\s*:\s*"([^"]+)"') {
+            $errorDetails.Code = $Matches[1]
+        }
+
+        if (($errorDetails.Message -eq 'Unknown error' -or $errorDetails.Message -eq $ErrorRecord.Exception.Message) -and
+            $exceptionText -match '"message"\s*:\s*"([^"]+)"') {
+            $errorDetails.Message = $Matches[1]
+        }
+
         if (-not $errorDetails.StatusCode -and $exceptionText -match 'Status:\s*(\d{3})') {
             $errorDetails.StatusCode = [int] $Matches[1]
         }
@@ -125,7 +135,8 @@ function Get-GraphEssentialsErrorDetails {
             $exceptionText -like '*Insufficient privileges*' -or
             $exceptionText -like '*insufficient*permission*' -or
             $exceptionText -like '*permission*denied*' -or
-            $exceptionText -like '*accessDenied*') {
+            $exceptionText -like '*accessDenied*' -or
+            $exceptionText -like '*PermissionScopeNotGranted*') {
             $errorDetails.IsPermissionDenied = $true
         }
 

--- a/Private/Get-GraphEssentialsErrorDetails.ps1
+++ b/Private/Get-GraphEssentialsErrorDetails.ps1
@@ -41,6 +41,10 @@ function Get-GraphEssentialsErrorDetails {
         Message = 'Unknown error'
         FullMessage = ''
         IsGraphError = $false
+        IsPermissionDenied = $false
+        IsNotFound = $false
+        IsTransient = $false
+        StatusCode = $null
         Original = $null
     }
 
@@ -52,7 +56,7 @@ function Get-GraphEssentialsErrorDetails {
         if ($ErrorRecord.ErrorDetails -and $ErrorRecord.ErrorDetails.Message) {
             # Extract just the error JSON part from the message
             # Look specifically for the error JSON object at the end of the message
-            if ($ErrorRecord.ErrorDetails.Message -match '({"\s*error"\s*:.+})$') {
+            if ($ErrorRecord.ErrorDetails.Message -match '(?s)({\s*"error"\s*:\s*.+})') {
                 $jsonContent = $Matches[1]
                 $errorResponse = $jsonContent | ConvertFrom-Json -ErrorAction Stop
 
@@ -79,6 +83,8 @@ function Get-GraphEssentialsErrorDetails {
             }
         }
 
+        $exceptionText = $ErrorRecord.Exception.ToString()
+
         # If we couldn't get details from ErrorDetails.Message, try other approaches
         if ($ErrorRecord.Exception.Response) {
             # Try to get status code and description from the response
@@ -87,6 +93,7 @@ function Get-GraphEssentialsErrorDetails {
 
             $errorDetails.Code = "HTTP $statusCode"
             $errorDetails.Message = "HTTP $statusCode $statusDesc"
+            $errorDetails.StatusCode = $statusCode
             $errorDetails.FullMessage = "$($FunctionName): Failed with HTTP status $statusCode $statusDesc"
         }
         elseif ($ErrorRecord.Exception.Message) {
@@ -95,15 +102,55 @@ function Get-GraphEssentialsErrorDetails {
             $errorDetails.FullMessage = "$($FunctionName): $($ErrorRecord.Exception.Message)"
         }
 
-        # Check specifically for permission errors in the exception string
-        $exceptionText = $ErrorRecord.Exception.ToString()
+        if (-not $errorDetails.StatusCode -and $exceptionText -match 'Status:\s*(\d{3})') {
+            $errorDetails.StatusCode = [int] $Matches[1]
+        }
+
+        if ($errorDetails.Code -eq 'Unknown' -and $exceptionText -match 'ErrorCode:\s*([^\r\n]+)') {
+            $errorDetails.Code = $Matches[1].Trim()
+        }
+
+        if (($errorDetails.Message -eq 'Unknown error' -or $errorDetails.Message -eq $ErrorRecord.Exception.Message) -and
+            $exceptionText -match 'Message:\s*([^\r\n]+)') {
+            $errorDetails.Message = $Matches[1].Trim()
+        }
+
+        if ($errorDetails.StatusCode -and $errorDetails.FullMessage -notlike '*HTTP status*') {
+            $errorDetails.FullMessage = "$($FunctionName): Failed with HTTP status $($errorDetails.StatusCode). $($errorDetails.Message)"
+        }
+
+        # Check specifically for permission, missing-resource and transient errors in the exception string
         if ($exceptionText -like '*Authorization_RequestDenied*' -or
             $exceptionText -like '*Forbidden*' -or
             $exceptionText -like '*Insufficient privileges*' -or
             $exceptionText -like '*insufficient*permission*' -or
             $exceptionText -like '*permission*denied*' -or
             $exceptionText -like '*accessDenied*') {
+            $errorDetails.IsPermissionDenied = $true
+        }
+
+        if ($errorDetails.StatusCode -eq 404 -or
+            $exceptionText -like '*Request_ResourceNotFound*' -or
+            $exceptionText -like '*resourceNotFound*') {
+            $errorDetails.IsNotFound = $true
+        }
+
+        if ($exceptionText -like '*transport stream*' -or
+            $exceptionText -like '*unexpected EOF*' -or
+            $exceptionText -like '*timed out*' -or
+            $exceptionText -like '*timeout*' -or
+            $errorDetails.StatusCode -eq 429 -or
+            $errorDetails.StatusCode -eq 503 -or
+            $errorDetails.StatusCode -eq 504) {
+            $errorDetails.IsTransient = $true
+        }
+
+        if ($errorDetails.IsPermissionDenied) {
             $errorDetails.FullMessage += "`n$($FunctionName): This often indicates insufficient permissions."
+        } elseif ($errorDetails.IsNotFound) {
+            $errorDetails.FullMessage += "`n$($FunctionName): This usually means the object or policy configuration does not exist in this tenant anymore."
+        } elseif ($errorDetails.IsTransient) {
+            $errorDetails.FullMessage += "`n$($FunctionName): This looks transient. Retrying the command usually succeeds."
         }
     }
     catch {

--- a/Private/Get-MyAuthenticationContext.ps1
+++ b/Private/Get-MyAuthenticationContext.ps1
@@ -40,7 +40,8 @@
             }
         }
     } catch {
-        Write-Warning -Message "Get-MyAuthenticationContext - Failed to get authentication contexts. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyAuthenticationContext'
+        Write-Warning -Message $errorInfo.FullMessage
         return
     }
 }

--- a/Private/Get-MyCrossTenantAccess.ps1
+++ b/Private/Get-MyCrossTenantAccess.ps1
@@ -73,7 +73,8 @@
 
         $Results
     } catch {
-        Write-Warning -Message "Get-MyCrossTenantAccess - Failed to get cross-tenant access policies. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyCrossTenantAccess'
+        Write-Warning -Message $errorInfo.FullMessage
         return
     }
 }

--- a/Private/Get-MyNamedLocation.ps1
+++ b/Private/Get-MyNamedLocation.ps1
@@ -39,7 +39,8 @@
             Write-Verbose -Message "Get-MyNamedLocation - Retrieved $($NamedLocations.Count) named locations"
         }
     } catch {
-        Write-Warning -Message "Get-MyNamedLocation - Failed to get named locations. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyNamedLocation'
+        Write-Warning -Message $errorInfo.FullMessage
         return
     }
 

--- a/Private/Get-MyTermsOfUse.ps1
+++ b/Private/Get-MyTermsOfUse.ps1
@@ -28,7 +28,8 @@
             return
         }
     } catch {
-        Write-Warning -Message "Get-MyTermsOfUse - Failed to get Terms of Use agreements. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyTermsOfUse'
+        Write-Warning -Message $errorInfo.FullMessage
         return
     }
 

--- a/Private/Get-MyUserAuthDetails.ps1
+++ b/Private/Get-MyUserAuthDetails.ps1
@@ -15,15 +15,18 @@ function Get-MyUserAuthDetails {
         $batchDetailItems = $DetailRequestsList.GetRange($i, [math]::Min($BatchSize, $DetailRequestsList.Count - $i))
         $batchDetailRequests = @()
         $detailIdMap = @{} # Map request ID to the original request item
+        $detailRequestsById = @{}
 
         foreach ($item in $batchDetailItems) {
             if (-not $item -or -not $item.BatchUrl) { continue }
-            $batchDetailRequests += @{
+            $request = @{
                 id     = $item.RequestId
                 method = "GET"
                 url    = $item.BatchUrl
             }
+            $batchDetailRequests += $request
             $detailIdMap[$item.RequestId] = $item # Map to the whole item
+            $detailRequestsById[$item.RequestId] = $request
         }
 
         if ($batchDetailRequests.Count -eq 0) { continue }
@@ -32,7 +35,7 @@ function Get-MyUserAuthDetails {
         $batchDetailResponses = Invoke-MyGraphBatchRequest -BatchRequests $batchDetailRequests -DataType $dataType
 
         if ($batchDetailResponses) {
-            $processedResults = Invoke-MyGraphBatchResponse -BatchResponses $batchDetailResponses -IdMap $detailIdMap -DataType $dataType
+            $processedResults = Invoke-MyGraphBatchResponse -BatchResponses $batchDetailResponses -IdMap $detailIdMap -DataType $dataType -RequestsById $detailRequestsById
             foreach ($result in $processedResults) {
                 $originalRequestItem = $result.Context
                 if ($null -eq $originalRequestItem) { continue } # Already warned

--- a/Private/Get-MyUserAuthSummaries.ps1
+++ b/Private/Get-MyUserAuthSummaries.ps1
@@ -15,18 +15,21 @@ function Get-MyUserAuthSummaries {
         $batchUserIds = $UserIds[$i..([math]::Min($i + $BatchSize - 1, $UserIds.Count - 1))]
         $batchRequests = @()
         $idMap = @{} # Map request ID to UserId for this batch
+        $requestsById = @{}
         $userCounterInBatch = 0
 
         foreach ($userId in $batchUserIds) {
             if (-not $userId) { continue }
             $userCounterInBatch++
             $requestId = "summary_$($i)_$($userCounterInBatch)" # Unique ID for summary requests
-            $batchRequests += @{
+            $request = @{
                 id     = $requestId
                 method = "GET"
                 url    = "/users/$userId/authentication/methods"
             }
+            $batchRequests += $request
             $idMap[$requestId] = $userId
+            $requestsById[$requestId] = $request
         }
 
         if ($batchRequests.Count -eq 0) { continue }
@@ -35,7 +38,7 @@ function Get-MyUserAuthSummaries {
         $batchResponses = Invoke-MyGraphBatchRequest -BatchRequests $batchRequests -DataType $dataType
 
         if ($batchResponses) {
-            $processedResults = Invoke-MyGraphBatchResponse -BatchResponses $batchResponses -IdMap $idMap -DataType $dataType
+            $processedResults = Invoke-MyGraphBatchResponse -BatchResponses $batchResponses -IdMap $idMap -DataType $dataType -RequestsById $requestsById
             foreach ($result in $processedResults) {
                 $currentUserId = $result.Context
                 if ($null -eq $currentUserId) { continue } # Already warned by Invoke-MyGraphBatchResponse

--- a/Private/Invoke-MyGraphBatchRequest.ps1
+++ b/Private/Invoke-MyGraphBatchRequest.ps1
@@ -1,10 +1,17 @@
 function Invoke-MyGraphBatchRequest {
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [array]$BatchRequests,
 
         [Parameter(Mandatory)]
-        [string]$DataType # For logging purposes (e.g., "Auth Methods Summary", "Method Details")
+        [string]$DataType, # For logging purposes (e.g., "Auth Methods Summary", "Method Details")
+
+        [Parameter()]
+        [int]$MaxRetryCount = 3,
+
+        [Parameter()]
+        [int]$RetryAttempt = 0
     )
 
     if ($BatchRequests.Count -eq 0) {
@@ -19,7 +26,16 @@ function Invoke-MyGraphBatchRequest {
         Write-Verbose "Invoke-MyGraphBatchRequest: Received response for $DataType."
         return $response
     } catch {
-        Write-Warning "Invoke-MyGraphBatchRequest: Batch request failed for $DataType. Error: $($_.Exception.Message)"
+        $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Invoke-MyGraphBatchRequest'
+        if (($errorInfo.IsTransient -or $errorInfo.StatusCode -eq 429) -and $RetryAttempt -lt $MaxRetryCount) {
+            $nextRetryAttempt = $RetryAttempt + 1
+            $retryDelaySeconds = [Math]::Max(5, [Math]::Min(30, 5 * $nextRetryAttempt))
+            Write-Warning "Invoke-MyGraphBatchRequest: Transient batch failure for $DataType. Waiting $retryDelaySeconds second(s) before retry $nextRetryAttempt/$MaxRetryCount. Error: $($errorInfo.Message)"
+            Start-Sleep -Seconds $retryDelaySeconds
+            return Invoke-MyGraphBatchRequest -BatchRequests $BatchRequests -DataType $DataType -MaxRetryCount $MaxRetryCount -RetryAttempt $nextRetryAttempt
+        }
+
+        Write-Warning "Invoke-MyGraphBatchRequest: Batch request failed for $DataType. Error: $($errorInfo.Message)"
         # Optionally add more details like the first few request IDs if needed for debugging
         # Write-Warning "Failed Batch Body (first part): $($body.Substring(0, [math]::Min($body.Length, 500)))..."
         return $null # Indicate failure

--- a/Private/Invoke-MyGraphBatchResponse.ps1
+++ b/Private/Invoke-MyGraphBatchResponse.ps1
@@ -8,10 +8,58 @@ function Invoke-MyGraphBatchResponse {
         [hashtable]$IdMap, # Maps Request ID to original context (e.g., UserId or RequestItem)
 
         [Parameter(Mandatory)]
-        [string]$DataType # Description of data being fetched (for logging)
+        [string]$DataType, # Description of data being fetched (for logging)
+
+        [Parameter()]
+        [hashtable]$RequestsById = @{},
+
+        [Parameter()]
+        [int]$MaxRetryCount = 3,
+
+        [Parameter()]
+        [int]$RetryAttempt = 0
     )
 
     $results = [System.Collections.Generic.List[object]]::new()
+    $throttledResponses = [System.Collections.Generic.List[object]]::new()
+    $throttledFailures = [System.Collections.Generic.List[object]]::new()
+
+    function Get-BatchRetryDelaySeconds {
+        param(
+            $BatchResponse
+        )
+
+        $delaySeconds = 0
+        if (-not $BatchResponse -or -not $BatchResponse.headers) {
+            return 5
+        }
+
+        foreach ($headerName in @('Retry-After', 'retry-after')) {
+            $headerProperty = $BatchResponse.headers.PSObject.Properties[$headerName]
+            if ($headerProperty -and $headerProperty.Value) {
+                $parsedDelay = 0
+                if ([int]::TryParse($headerProperty.Value.ToString(), [ref] $parsedDelay)) {
+                    $delaySeconds = [Math]::Max($delaySeconds, $parsedDelay)
+                }
+            }
+        }
+
+        foreach ($headerName in @('x-ms-retry-after-ms', 'X-MS-Retry-After-MS')) {
+            $headerProperty = $BatchResponse.headers.PSObject.Properties[$headerName]
+            if ($headerProperty -and $headerProperty.Value) {
+                $parsedDelayMs = 0
+                if ([int]::TryParse($headerProperty.Value.ToString(), [ref] $parsedDelayMs)) {
+                    $delaySeconds = [Math]::Max($delaySeconds, [Math]::Ceiling($parsedDelayMs / 1000))
+                }
+            }
+        }
+
+        if ($delaySeconds -le 0) {
+            $delaySeconds = 5
+        }
+
+        return $delaySeconds
+    }
 
     if (-not $BatchResponses -or -not $BatchResponses.responses) {
         Write-Warning "Invoke-MyGraphBatchResponse: Invalid or empty batch response received for $DataType."
@@ -57,6 +105,25 @@ function Invoke-MyGraphBatchResponse {
                     Body      = $response.body
                     Error     = $null
                 })
+        } elseif ($response.status -eq 429) {
+            if ($RetryAttempt -lt $MaxRetryCount -and $RequestsById.ContainsKey($response.id)) {
+                $throttledResponses.Add($response)
+            } else {
+                $throttledFailures.Add([PSCustomObject]@{
+                        RequestId = $response.id
+                        Context   = $originalContext
+                        Status    = $response.status
+                        Body      = $response.body
+                    })
+                $results.Add([PSCustomObject]@{
+                        RequestId = $response.id
+                        Context   = $originalContext
+                        Success   = $false
+                        Status    = $response.status
+                        Body      = $response.body
+                        Error     = "Request failed with status code $($response.status) after retrying throttled batch items."
+                    })
+            }
         } else {
             # Failure
             Write-Warning "Invoke-MyGraphBatchResponse: Failed request in batch for $DataType (Context: '$originalContext', Response ID: $($response.id)). Status: $($response.status). Body: $($response.body | ConvertTo-Json -Depth 3 -Compress)"
@@ -70,6 +137,75 @@ function Invoke-MyGraphBatchResponse {
                 })
         }
     }
+
+    if ($throttledResponses.Count -gt 0) {
+        $retryAttemptNumber = $RetryAttempt + 1
+        $retryDelaySeconds = 0
+        foreach ($throttledResponse in $throttledResponses) {
+            $retryDelaySeconds = [Math]::Max($retryDelaySeconds, (Get-BatchRetryDelaySeconds -BatchResponse $throttledResponse))
+        }
+
+        Write-Warning "Invoke-MyGraphBatchResponse: Graph throttled $($throttledResponses.Count) request(s) for $DataType. Waiting $retryDelaySeconds second(s) before retry $retryAttemptNumber/$MaxRetryCount."
+        Start-Sleep -Seconds $retryDelaySeconds
+
+        $retryRequests = [System.Collections.Generic.List[object]]::new()
+        foreach ($throttledResponse in $throttledResponses) {
+            $retryRequest = $RequestsById[$throttledResponse.id]
+            if ($null -ne $retryRequest) {
+                $retryRequests.Add($retryRequest)
+            }
+        }
+
+        $retryChunkSize = [Math]::Min(5, [Math]::Max(1, $retryRequests.Count))
+        for ($i = 0; $i -lt $retryRequests.Count; $i += $retryChunkSize) {
+            $currentRetryBatch = $retryRequests[$i..([Math]::Min($i + $retryChunkSize - 1, $retryRequests.Count - 1))]
+            $retryIdMap = @{}
+            $retryRequestsById = @{}
+
+            foreach ($request in $currentRetryBatch) {
+                $retryIdMap[$request.id] = $IdMap[$request.id]
+                $retryRequestsById[$request.id] = $request
+            }
+
+            $retryDataType = "$DataType (Retry $retryAttemptNumber)"
+            $retryBatchResponse = Invoke-MyGraphBatchRequest -BatchRequests $currentRetryBatch -DataType $retryDataType
+
+            if ($retryBatchResponse) {
+                $retryResults = Invoke-MyGraphBatchResponse -BatchResponses $retryBatchResponse -IdMap $retryIdMap -DataType $retryDataType -RequestsById $retryRequestsById -MaxRetryCount $MaxRetryCount -RetryAttempt $retryAttemptNumber
+                foreach ($retryResult in $retryResults) {
+                    $results.Add($retryResult)
+                }
+            } else {
+                foreach ($request in $currentRetryBatch) {
+                    $results.Add([PSCustomObject]@{
+                            RequestId = $request.id
+                            Context   = $retryIdMap[$request.id]
+                            Success   = $false
+                            Status    = $null
+                            Body      = $null
+                            Error     = "Batch retry request failed before a response was received."
+                        })
+                }
+            }
+        }
+    }
+
+    if ($throttledFailures.Count -gt 0) {
+        $exampleContexts = $throttledFailures |
+        Select-Object -First 5 |
+        ForEach-Object { $_.Context } |
+        Where-Object { $null -ne $_ } |
+        ForEach-Object { "'$_'" }
+
+        $exampleSuffix = if ($exampleContexts.Count -gt 0) {
+            " Example contexts: $($exampleContexts -join ', ')."
+        } else {
+            ''
+        }
+
+        Write-Warning "Invoke-MyGraphBatchResponse: $($throttledFailures.Count) request(s) for $DataType remained throttled after $RetryAttempt retry attempt(s).$exampleSuffix"
+    }
+
     Write-Verbose "Invoke-MyGraphBatchResponse: Finished processing responses for $DataType."
     return $results
 }

--- a/Private/Resolve-GraphEssentialsOwner.ps1
+++ b/Private/Resolve-GraphEssentialsOwner.ps1
@@ -33,6 +33,7 @@ function Resolve-GraphEssentialsOwner {
     if (-not $mail -and $OwnerObject.PSObject.Properties['Mail']) { $mail = $OwnerObject.Mail }
 
     $permDenied = $false
+    $missingObject = $false
 
     # If missing, try live lookups (user first, then service principal) using cached results
     if ($id) {
@@ -53,15 +54,14 @@ function Resolve-GraphEssentialsOwner {
                     if (-not $oDataType) { $oDataType = '#microsoft.graph.user' }
                 }
             } catch {
-                # Note permission issue so we can surface a hint.
-                $exceptionText = $_.Exception.ToString()
-                if ($exceptionText -like '*Authorization_RequestDenied*' -or
-                    $exceptionText -like '*Insufficient privileges*' -or
-                    $exceptionText -like '*insufficient*permission*' -or
-                    $exceptionText -like '*permission*denied*' -or
-                    $exceptionText -like '*accessDenied*' -or
-                    $exceptionText -like '*Forbidden*') {
+                $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Resolve-GraphEssentialsOwner'
+                if ($errorInfo.IsPermissionDenied) {
                     $permDenied = $true
+                } elseif ($errorInfo.IsNotFound) {
+                    $missingObject = $true
+                    Write-Verbose "Resolve-GraphEssentialsOwner: Owner object $id no longer resolves as a user."
+                } else {
+                    Write-Verbose $errorInfo.FullMessage
                 }
             }
         }
@@ -79,7 +79,15 @@ function Resolve-GraphEssentialsOwner {
                     if (-not $appId -and $spResolved.PSObject.Properties['AppId']) { $appId = $spResolved.AppId }
                     if (-not $oDataType) { $oDataType = '#microsoft.graph.servicePrincipal' }
                 }
-            } catch { }
+            } catch {
+                $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Resolve-GraphEssentialsOwner'
+                if ($errorInfo.IsNotFound) {
+                    $missingObject = $true
+                    Write-Verbose "Resolve-GraphEssentialsOwner: Owner object $id no longer resolves as a service principal."
+                } elseif (-not $errorInfo.IsPermissionDenied) {
+                    Write-Verbose $errorInfo.FullMessage
+                }
+            }
         }
     }
 
@@ -87,6 +95,9 @@ function Resolve-GraphEssentialsOwner {
         $dispName = '(Permission Denied)'
         $oDataType = '#microsoft.graph.user'
         Write-Verbose 'Resolve-GraphEssentialsOwner: Permission missing: add User.Read.All or Directory.Read.All.'
+    } elseif ($missingObject -and (-not $dispName) -and (-not $upn) -and (-not $mail)) {
+        $dispName = '(Deleted or missing object)'
+        Write-Verbose "Resolve-GraphEssentialsOwner: Owner object $id appears to have been deleted or is no longer resolvable."
     }
 
     [pscustomobject]@{

--- a/Public/Get-MyRoleHistory.ps1
+++ b/Public/Get-MyRoleHistory.ps1
@@ -53,7 +53,9 @@
 
     .NOTES
     This function requires the Microsoft.Graph.Identity.Governance module and appropriate permissions.
-    Typically requires RoleManagement.Read.Directory or Directory.Read.All permissions.
+    Reading PIM history requests currently requires RoleAssignmentSchedule.ReadWrite.Directory and
+    RoleEligibilitySchedule.ReadWrite.Directory, or the broader RoleManagement.ReadWrite.Directory
+    permission, with admin consent.
     #>
     [CmdletBinding()]
     param(
@@ -67,13 +69,33 @@
 
     $ErrorsCount = 0
     $StartDate = (Get-Date).AddDays(-$DaysBack).ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $PermissionIssues = [System.Collections.Generic.List[string]]::new()
+
+    function Write-RoleHistoryWarning {
+        param(
+            [string] $Operation,
+            [System.Management.Automation.ErrorRecord] $ErrorRecord,
+            [string[]] $RequiredApplicationPermissions
+        )
+
+        $errorInfo = $ErrorRecord | Get-GraphEssentialsErrorDetails -FunctionName 'Get-MyRoleHistory'
+
+        if ($RequiredApplicationPermissions -and $errorInfo.IsPermissionDenied) {
+            $permissions = $RequiredApplicationPermissions -join ' or '
+            $PermissionIssues.Add("$Operation requires application permission $permissions with admin consent.") | Out-Null
+            Write-Warning -Message "Get-MyRoleHistory - Missing Microsoft Graph application permission for $Operation. Add $permissions and grant admin consent."
+            return
+        }
+
+        Write-Warning -Message "Get-MyRoleHistory - Failed to get $Operation. Error: $($errorInfo.Message)"
+    }
 
     # Get all required data with error handling
     try {
         Write-Verbose "Getting users..."
         $Users = Get-MgUser -ErrorAction Stop -All -Property DisplayName, CreatedDateTime, 'AccountEnabled', 'Mail', 'UserPrincipalName', 'Id', 'UserType', 'OnPremisesDistinguishedName', 'OnPremisesSamAccountName'
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get users. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'users' -ErrorRecord $_
         $ErrorsCount++
     }
 
@@ -81,7 +103,7 @@
         Write-Verbose "Getting groups..."
         $Groups = Get-MgGroup -ErrorAction Stop -All -Filter "IsAssignableToRole eq true" -Property CreatedDateTime, Id, DisplayName, Mail, SecurityEnabled
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get groups. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'groups' -ErrorRecord $_
         $ErrorsCount++
     }
 
@@ -89,7 +111,7 @@
         Write-Verbose "Getting service principals..."
         $ServicePrincipals = Get-MgServicePrincipal -ErrorAction Stop -All -Property CreatedDateTime, 'ServicePrincipalType', 'DisplayName', 'AccountEnabled', 'Id', 'AppId'
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get service principals. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'service principals' -ErrorRecord $_
         $ErrorsCount++
     }
 
@@ -97,7 +119,7 @@
         Write-Verbose "Getting role definitions..."
         $Roles = Get-MgRoleManagementDirectoryRoleDefinition -ErrorAction Stop -All
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get roles. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'role definitions' -ErrorRecord $_
         $ErrorsCount++
     }
 
@@ -106,7 +128,10 @@
         $Filter = "createdDateTime ge $StartDate"
         $RoleAssignmentRequests = Get-MgRoleManagementDirectoryRoleAssignmentScheduleRequest -ErrorAction Stop -All -Filter $Filter
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get role assignment schedule requests. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'role assignment schedule requests' -ErrorRecord $_ -RequiredApplicationPermissions @(
+            'RoleAssignmentSchedule.ReadWrite.Directory',
+            'RoleManagement.ReadWrite.Directory'
+        )
         $ErrorsCount++
     }
 
@@ -115,12 +140,19 @@
         $Filter = "createdDateTime ge $StartDate"
         $RoleEligibilityRequests = Get-MgRoleManagementDirectoryRoleEligibilityScheduleRequest -ErrorAction Stop -All -Filter $Filter
     } catch {
-        Write-Warning -Message "Get-MyRoleHistory - Failed to get role eligibility schedule requests. Error: $($_.Exception.Message)"
+        Write-RoleHistoryWarning -Operation 'role eligibility schedule requests' -ErrorRecord $_ -RequiredApplicationPermissions @(
+            'RoleEligibilitySchedule.ReadWrite.Directory',
+            'RoleManagement.ReadWrite.Directory'
+        )
         $ErrorsCount++
     }
 
     if ($ErrorsCount -gt 0) {
-        Write-Error "Failed to retrieve required data. Cannot continue."
+        if ($PermissionIssues.Count -gt 0) {
+            Write-Error "Get-MyRoleHistory - Missing Microsoft Graph application permissions for PIM history. $($PermissionIssues -join ' ')"
+        } else {
+            Write-Error "Get-MyRoleHistory - Failed to retrieve required data. Cannot continue."
+        }
         return
     }
 

--- a/Public/Get-MyRoleHistory.ps1
+++ b/Public/Get-MyRoleHistory.ps1
@@ -70,6 +70,8 @@
     $ErrorsCount = 0
     $StartDate = (Get-Date).AddDays(-$DaysBack).ToString("yyyy-MM-ddTHH:mm:ssZ")
     $PermissionIssues = [System.Collections.Generic.List[string]]::new()
+    $RoleAssignmentRequests = @()
+    $RoleEligibilityRequests = @()
 
     function Write-RoleHistoryWarning {
         param(
@@ -132,7 +134,6 @@
             'RoleAssignmentSchedule.ReadWrite.Directory',
             'RoleManagement.ReadWrite.Directory'
         )
-        $ErrorsCount++
     }
 
     try {
@@ -144,16 +145,15 @@
             'RoleEligibilitySchedule.ReadWrite.Directory',
             'RoleManagement.ReadWrite.Directory'
         )
-        $ErrorsCount++
     }
 
     if ($ErrorsCount -gt 0) {
-        if ($PermissionIssues.Count -gt 0) {
-            Write-Error "Get-MyRoleHistory - Missing Microsoft Graph application permissions for PIM history. $($PermissionIssues -join ' ')"
-        } else {
-            Write-Error "Get-MyRoleHistory - Failed to retrieve required data. Cannot continue."
-        }
+        Write-Error "Get-MyRoleHistory - Failed to retrieve required data. Cannot continue."
         return
+    }
+
+    if ($PermissionIssues.Count -gt 0 -and -not $RoleAssignmentRequests -and -not $RoleEligibilityRequests) {
+        Write-Verbose "Get-MyRoleHistory - Returning no PIM history because request-history permissions are missing. $($PermissionIssues -join ' ')"
     }
 
     # Build caches for quick lookups

--- a/Public/Get-MyUserAuthentication.ps1
+++ b/Public/Get-MyUserAuthentication.ps1
@@ -93,6 +93,7 @@ function Get-MyUserAuthentication {
         # 5. Assemble Final Results
         Write-Verbose "Get-MyUserAuthentication - Assembling final results..."
         $FinalResults = [System.Collections.Generic.List[object]]::new()
+        $SkippedUsers = [System.Collections.Generic.List[string]]::new()
 
         foreach ($UserId in $intermediateResults.Keys) {
             $intermediate = $intermediateResults[$UserId]
@@ -102,7 +103,11 @@ function Get-MyUserAuthentication {
 
             # If summary fetch failed for this user, skip assembly
             if ($null -eq $AuthMethods) {
-                Write-Warning "Get-MyUserAuthentication: Skipping result assembly for $($user.UserPrincipalName) as summary fetch failed."
+                if ($User -and $User.UserPrincipalName) {
+                    $SkippedUsers.Add($User.UserPrincipalName) | Out-Null
+                } elseif ($UserId) {
+                    $SkippedUsers.Add($UserId) | Out-Null
+                }
                 continue
             }
 
@@ -235,6 +240,17 @@ function Get-MyUserAuthentication {
             $FinalResults.Add($resultObject)
 
         } # End foreach ($UserId in $intermediateResults.Keys)
+
+        if ($SkippedUsers.Count -gt 0) {
+            $exampleSkippedUsers = $SkippedUsers | Select-Object -First 5
+            $exampleSuffix = if ($exampleSkippedUsers.Count -gt 0) {
+                " Examples: $($exampleSkippedUsers -join ', ')."
+            } else {
+                ''
+            }
+
+            Write-Warning "Get-MyUserAuthentication: Skipped $($SkippedUsers.Count) user(s) because authentication summary retrieval failed or was throttled.$exampleSuffix"
+        }
 
         Write-Verbose "Get-MyUserAuthentication: Finished assembling results. Returning $($FinalResults.Count) objects."
         return $FinalResults

--- a/Public/Show-MyRole.ps1
+++ b/Public/Show-MyRole.ps1
@@ -139,7 +139,7 @@ function Show-MyRole {
     }
 
     if (-not $RoleHistory -or $RoleHistory.Count -eq 0) {
-        Write-Warning -Message "Show-MyRole - No PIM history found for the specified period ($DaysBack days)"
+        Write-Verbose -Message "Show-MyRole - No PIM history available for the specified period ($DaysBack days). This can mean no activity or missing Graph permissions."
         $RoleHistory = @()
     }
 
@@ -548,7 +548,7 @@ function Show-MyRole {
                     }
                 }
             } else {
-                New-HTMLSection -HeaderText "No PIM History Found" {
+                New-HTMLSection -HeaderText "No PIM History Available" {
                     New-HTMLPanel -Invisible {
                         New-HTMLContainer {
                             New-HTMLText -FontSize 12pt -TextBlock {

--- a/Public/Show-MyRole.ps1
+++ b/Public/Show-MyRole.ps1
@@ -562,7 +562,7 @@ function Show-MyRole {
                             } -FontSize 11pt
 
                             New-HTMLText -FontSize 11pt -TextBlock {
-                                "Required permissions for PIM history: RoleManagement.Read.Directory, RoleAssignmentSchedule.Read.Directory"
+                                "Required permissions for PIM history: RoleAssignmentSchedule.ReadWrite.Directory and RoleEligibilitySchedule.ReadWrite.Directory, or the broader RoleManagement.ReadWrite.Directory"
                             }
                         }
                     }


### PR DESCRIPTION
## What changed
- made Graph permission and missing-resource failures produce concise, actionable messages instead of raw SDK exception dumps
- downgraded expected tenant-specific not-found cases to softer output where the report can continue
- kept role reporting usable when PIM history request permissions are missing by returning an empty history section instead of aborting the report
- added targeted retry and backoff handling for throttled Graph batch subrequests used by auth-method summary/detail collection
- collapsed per-item and per-user throttle noise into summary warnings so logs stay readable

## Why
Several legacy report paths were technically catching Graph failures already, but they still looked catastrophic in logs. We wanted the reports to continue when the failure is expected, tenant-specific, permission-related, or transient.

## Root causes addressed
- stale or deleted Graph objects returning 404 during follow-up lookups
- tenant-specific auth-method policy/configuration objects that are legitimately absent
- PIM history request endpoints requiring broader app permissions than the rest of the role report
- Graph 429 throttling on batched authentication-method requests

## Validation
- parsed all touched PowerShell files with [System.Management.Automation.Language.Parser]::ParseFile(...)
- exercised the batch-response retry path with a targeted PowerShell simulation of a throttled subrequest