### PR TITLE
[codex] Improve guest and user sign-in review reports

### DIFF
--- a/Private/Configuration.Guests.ps1
+++ b/Private/Configuration.Guests.ps1
@@ -15,13 +15,22 @@ $Script:Guests = [ordered] @{
         $pendingGuests = 0
         $acceptedGuests = 0
         $neverSignedInGuests = 0
+        $neverSuccessfulSignInGuests = 0
+        $staleGuests = 0
+        $recentGuests = 0
         $guestWithRoles = 0
         $guestWithLicenses = 0
         $guestDomains = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
         $domainCounts = @{}
         $stateCounts = @{}
+        $creationTypeCounts = @{}
         $pendingAccounts = [System.Collections.Generic.List[object]]::new()
         $acceptedAccounts = [System.Collections.Generic.List[object]]::new()
+        $neverSuccessfulAccounts = [System.Collections.Generic.List[object]]::new()
+        $staleAccounts = [System.Collections.Generic.List[object]]::new()
+        $recentAccounts = [System.Collections.Generic.List[object]]::new()
+        $privilegedAccounts = [System.Collections.Generic.List[object]]::new()
+        $licensedAccounts = [System.Collections.Generic.List[object]]::new()
         $reviewCandidates = [System.Collections.Generic.List[object]]::new()
 
         foreach ($guest in $guestData) {
@@ -42,11 +51,17 @@ $Script:Guests = [ordered] @{
             if ($guest.NeverSignedIn) {
                 $neverSignedInGuests++
             }
+            if ($guest.NeverSuccessfullySignedIn) {
+                $neverSuccessfulSignInGuests++
+                $neverSuccessfulAccounts.Add($guest)
+            }
             if ($guest.HasRoles) {
                 $guestWithRoles++
+                $privilegedAccounts.Add($guest)
             }
             if ($guest.HasLicenses) {
                 $guestWithLicenses++
+                $licensedAccounts.Add($guest)
             }
             if ($guest.GuestDomain) {
                 [void] $guestDomains.Add($guest.GuestDomain)
@@ -62,6 +77,22 @@ $Script:Guests = [ordered] @{
             }
             $stateCounts[$guestState]++
 
+            $creationType = if ($guest.CreationType) { $guest.CreationType } else { 'Unknown' }
+            if (-not $creationTypeCounts.ContainsKey($creationType)) {
+                $creationTypeCounts[$creationType] = 0
+            }
+            $creationTypeCounts[$creationType]++
+
+            if ($null -ne $guest.LastSuccessfulSignInDaysAgo -and $guest.LastSuccessfulSignInDaysAgo -gt 180) {
+                $staleGuests++
+                $staleAccounts.Add($guest)
+            }
+
+            if ($null -ne $guest.LastSuccessfulSignInDaysAgo -and $guest.LastSuccessfulSignInDaysAgo -le 30) {
+                $recentGuests++
+                $recentAccounts.Add($guest)
+            }
+
             $reviewFlags = [System.Collections.Generic.List[string]]::new()
             if (-not $guest.Enabled) {
                 $reviewFlags.Add('Disabled')
@@ -72,8 +103,14 @@ $Script:Guests = [ordered] @{
             if ($guest.NeverSignedIn) {
                 $reviewFlags.Add('Never signed in')
             }
+            if ($guest.NeverSuccessfullySignedIn) {
+                $reviewFlags.Add('No successful sign-in')
+            }
             if (($null -ne $guest.LastSignInDaysAgo -and $guest.LastSignInDaysAgo -gt 180) -or ($null -ne $guest.LastNonInteractiveSignInDaysAgo -and $guest.LastNonInteractiveSignInDaysAgo -gt 180)) {
                 $reviewFlags.Add('Stale sign-in')
+            }
+            if ($null -ne $guest.LastSuccessfulSignInDaysAgo -and $guest.LastSuccessfulSignInDaysAgo -gt 180) {
+                $reviewFlags.Add('No successful sign-in 180+ days')
             }
             if ($guest.HasRoles) {
                 $reviewFlags.Add('Privileged')
@@ -96,6 +133,9 @@ $Script:Guests = [ordered] @{
                 PendingAcceptance  = $pendingGuests
                 AcceptedGuests     = $acceptedGuests
                 NeverSignedIn      = $neverSignedInGuests
+                NeverSuccessfulSignIn = $neverSuccessfulSignInGuests
+                StaleSuccessful180Days = $staleGuests
+                ActiveSuccessful30Days = $recentGuests
                 GuestsWithRoles    = $guestWithRoles
                 GuestsWithLicenses = $guestWithLicenses
                 DistinctDomains    = $guestDomains.Count
@@ -121,6 +161,7 @@ $Script:Guests = [ordered] @{
         ) | Sort-Object Count -Descending
 
         $signInDistribution = @(
+            [PSCustomObject]@{ Name = 'No activity data'; Count = @($guestData.Where({ $null -eq $_.NeverSignedIn -and $null -eq $_.LastSignInDaysAgo -and $null -eq $_.LastNonInteractiveSignInDaysAgo })).Count }
             [PSCustomObject]@{ Name = 'Never signed in'; Count = $neverSignedInGuests }
             [PSCustomObject]@{ Name = '0-30 days'; Count = @($guestData.Where({ $null -ne $_.LastSignInDaysAgo -and $_.LastSignInDaysAgo -le 30 })).Count }
             [PSCustomObject]@{ Name = '31-90 days'; Count = @($guestData.Where({ $null -ne $_.LastSignInDaysAgo -and $_.LastSignInDaysAgo -gt 30 -and $_.LastSignInDaysAgo -le 90 })).Count }
@@ -128,14 +169,34 @@ $Script:Guests = [ordered] @{
             [PSCustomObject]@{ Name = '180+ days'; Count = @($guestData.Where({ $null -ne $_.LastSignInDaysAgo -and $_.LastSignInDaysAgo -gt 180 })).Count }
         )
 
+        $successfulSignInDistribution = @(
+            [PSCustomObject]@{ Name = 'No activity data'; Count = @($guestData.Where({ $null -eq $_.NeverSuccessfullySignedIn -and $null -eq $_.LastSuccessfulSignInDaysAgo })).Count }
+            [PSCustomObject]@{ Name = 'No successful sign-in'; Count = $neverSuccessfulSignInGuests }
+            [PSCustomObject]@{ Name = '0-30 days'; Count = @($guestData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -le 30 })).Count }
+            [PSCustomObject]@{ Name = '31-90 days'; Count = @($guestData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 30 -and $_.LastSuccessfulSignInDaysAgo -le 90 })).Count }
+            [PSCustomObject]@{ Name = '91-180 days'; Count = @($guestData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 90 -and $_.LastSuccessfulSignInDaysAgo -le 180 })).Count }
+            [PSCustomObject]@{ Name = '180+ days'; Count = @($guestData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 180 })).Count }
+        )
+
         $accessDistribution = @(
             [PSCustomObject]@{ Name = 'Enabled'; Count = $enabledGuests }
             [PSCustomObject]@{ Name = 'Disabled'; Count = $disabledGuests }
             [PSCustomObject]@{ Name = 'Pending acceptance'; Count = $pendingGuests }
             [PSCustomObject]@{ Name = 'Never signed in'; Count = $neverSignedInGuests }
+            [PSCustomObject]@{ Name = 'No successful sign-in'; Count = $neverSuccessfulSignInGuests }
+            [PSCustomObject]@{ Name = 'Successful sign-in 180+ days'; Count = $staleGuests }
             [PSCustomObject]@{ Name = 'With roles'; Count = $guestWithRoles }
             [PSCustomObject]@{ Name = 'With licenses'; Count = $guestWithLicenses }
         )
+
+        $creationTypeDistribution = @(
+            foreach ($key in $creationTypeCounts.Keys) {
+                [PSCustomObject]@{
+                    Name  = $key
+                    Count = $creationTypeCounts[$key]
+                }
+            }
+        ) | Sort-Object Count -Descending
 
         $authenticationSummary = @()
         try {
@@ -226,9 +287,16 @@ $Script:Guests = [ordered] @{
             DomainDistribution    = $domainDistribution
             StateDistribution     = $stateDistribution
             SignInDistribution    = $signInDistribution
+            SuccessfulSignInDistribution = $successfulSignInDistribution
             AccessDistribution    = $accessDistribution
+            CreationTypeDistribution = $creationTypeDistribution
             PendingAccounts       = @($pendingAccounts)
             AcceptedAccounts      = @($acceptedAccounts)
+            NeverSuccessfulAccounts = @($neverSuccessfulAccounts)
+            StaleAccounts         = @($staleAccounts)
+            RecentAccounts        = @($recentAccounts)
+            PrivilegedAccounts    = @($privilegedAccounts)
+            LicensedAccounts      = @($licensedAccounts)
             ReviewCandidates      = @($reviewCandidates)
             AuthenticationPolicy  = $authenticationSummary
             TermsOfUse            = $termsOfUseSummary
@@ -253,12 +321,13 @@ $Script:Guests = [ordered] @{
                             New-HTMLInfoCard -Title 'Total External Accounts' -Number $overview.TotalGuests -Subtitle 'All guest and external accounts in scope' -Icon '👥' -IconColor '#0078d4' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                             New-HTMLInfoCard -Title 'Enabled / Disabled' -Number "$($overview.EnabledGuests) / $($overview.DisabledGuests)" -Subtitle 'Account state split' -Icon '✅' -IconColor '#198754' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                             New-HTMLInfoCard -Title 'Pending / Accepted' -Number "$($overview.PendingAcceptance) / $($overview.AcceptedGuests)" -Subtitle 'Invitation lifecycle split' -Icon '📨' -IconColor '#fd7e14' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
-                            New-HTMLInfoCard -Title 'Never Signed In' -Number $overview.NeverSignedIn -Subtitle 'External accounts without observed sign-in activity' -Icon '⏱️' -IconColor '#dc3545' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                            New-HTMLInfoCard -Title 'No Successful Sign-in' -Number $overview.NeverSuccessfulSignIn -Subtitle 'External accounts without recorded successful sign-in activity' -Icon '⏱️' -IconColor '#dc3545' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                         }
                         New-HTMLSection -Invisible {
                             New-HTMLInfoCard -Title 'Accounts With Roles' -Number $overview.GuestsWithRoles -Subtitle 'Privileged external identities' -Icon '🛡️' -IconColor '#6f42c1' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                             New-HTMLInfoCard -Title 'Accounts With Licenses' -Number $overview.GuestsWithLicenses -Subtitle 'Licensed external identities' -Icon '🎫' -IconColor '#20c997' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
-                            New-HTMLInfoCard -Title 'Distinct Domains' -Number $overview.DistinctDomains -Subtitle 'Partner domains represented' -Icon '🌐' -IconColor '#ffc107' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                            New-HTMLInfoCard -Title 'Successful 180+ Days' -Number $overview.StaleSuccessful180Days -Subtitle 'No recent successful sign-in recorded' -Icon '📉' -IconColor '#ffc107' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                            New-HTMLInfoCard -Title 'Distinct Domains' -Number $overview.DistinctDomains -Subtitle 'Partner domains represented' -Icon '🌐' -IconColor '#0dcaf0' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                         }
                         New-HTMLSection -Invisible {
                             New-HTMLPanel {
@@ -269,8 +338,8 @@ $Script:Guests = [ordered] @{
                                 }
                             }
                             New-HTMLPanel {
-                                New-HTMLChart -Title 'External Sign-in Recency' {
-                                    foreach ($item in $guestSummary.SignInDistribution) {
+                                New-HTMLChart -Title 'External Successful Sign-in Recency' {
+                                    foreach ($item in $guestSummary.SuccessfulSignInDistribution) {
                                         New-ChartPie -Name $item.Name -Value $item.Count
                                     }
                                 }
@@ -280,6 +349,22 @@ $Script:Guests = [ordered] @{
                             New-HTMLPanel {
                                 New-HTMLChart -Title 'External Access Indicators' {
                                     foreach ($item in $guestSummary.AccessDistribution) {
+                                        New-ChartPie -Name $item.Name -Value $item.Count
+                                    }
+                                }
+                            }
+                            New-HTMLPanel {
+                                New-HTMLChart -Title 'Creation Type Distribution' {
+                                    foreach ($item in $guestSummary.CreationTypeDistribution) {
+                                        New-ChartBar -Name $item.Name -Value $item.Count
+                                    }
+                                }
+                            }
+                        }
+                        New-HTMLSection -HeaderText 'Sign-in Signals' -Invisible {
+                            New-HTMLPanel {
+                                New-HTMLChart -Title 'External Sign-in Recency' {
+                                    foreach ($item in $guestSummary.SignInDistribution) {
                                         New-ChartPie -Name $item.Name -Value $item.Count
                                     }
                                 }
@@ -335,6 +420,10 @@ $Script:Guests = [ordered] @{
                         New-HTMLTableCondition -Name 'ExternalUserState' -Operator eq -Value '' -ComparisonType string -BackgroundColor OldGold -HighlightHeaders 'ExternalUserState'
 
                         New-HTMLTableCondition -Name 'NeverSignedIn' -Operator eq -Value $true -ComparisonType string -BackgroundColor PeachOrange -HighlightHeaders 'NeverSignedIn', 'LastSignInDateTime', 'LastNonInteractiveSignInDateTime'
+                        New-HTMLTableCondition -Name 'NeverSuccessfullySignedIn' -Operator eq -Value $true -ComparisonType string -BackgroundColor CoralRed -HighlightHeaders 'NeverSuccessfullySignedIn', 'LastSuccessfulSignInDateTime'
+                        New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Non-interactive only' -ComparisonType string -BackgroundColor LightSkyBlue -HighlightHeaders 'SignInPattern', 'LastNonInteractiveSignInDateTime'
+                        New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Interactive only' -ComparisonType string -BackgroundColor LightGreen -HighlightHeaders 'SignInPattern', 'LastSignInDateTime'
+                        New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Interactive + non-interactive' -ComparisonType string -BackgroundColor MediumSpringGreen -HighlightHeaders 'SignInPattern'
                         New-HTMLTableCondition -Name 'HasRoles' -Operator eq -Value $true -ComparisonType string -BackgroundColor LightSkyBlue -HighlightHeaders 'HasRoles', 'RoleCount', 'Roles'
                         New-HTMLTableCondition -Name 'HasLicenses' -Operator eq -Value $true -ComparisonType string -BackgroundColor LightGreen -HighlightHeaders 'HasLicenses', 'LicenseCount', 'Licenses'
 
@@ -347,6 +436,11 @@ $Script:Guests = [ordered] @{
                         New-HTMLTableCondition -Name 'LastNonInteractiveSignInDaysAgo' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastNonInteractiveSignInDaysAgo', 'LastNonInteractiveSignInDateTime'
                         New-HTMLTableCondition -Name 'LastNonInteractiveSignInDaysAgo' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastNonInteractiveSignInDaysAgo', 'LastNonInteractiveSignInDateTime'
                         New-HTMLTableCondition -Name 'LastNonInteractiveSignInDaysAgo' -Value 30 -Operator le -ComparisonType number -BackgroundColor MediumSpringGreen -HighlightHeaders 'LastNonInteractiveSignInDaysAgo', 'LastNonInteractiveSignInDateTime'
+
+                        New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 180 -Operator gt -ComparisonType number -BackgroundColor CoralRed -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                        New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                        New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                        New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 30 -Operator le -ComparisonType number -BackgroundColor MediumSpringGreen -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
 
                         New-HTMLTableCondition -Name 'LicensesStatus' -Operator contains -Value 'Direct' -ComparisonType string -BackgroundColor LightSkyBlue
                         New-HTMLTableCondition -Name 'LicensesStatus' -Operator contains -Value 'Group' -ComparisonType string -BackgroundColor LightGreen
@@ -383,6 +477,61 @@ $Script:Guests = [ordered] @{
                             } else {
                                 New-HTMLSection -HeaderText 'Accepted External Accounts' {
                                     New-HTMLText -Text 'No accepted external accounts found.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "No Successful Sign-in ($(@($guestSummary.NeverSuccessfulAccounts).Count))" {
+                            if (@($guestSummary.NeverSuccessfulAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'External Accounts Without Successful Sign-in' {
+                                    New-HTMLTable -DataTable $guestSummary.NeverSuccessfulAccounts -Filtering $guestTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'External Accounts Without Successful Sign-in' {
+                                    New-HTMLText -Text 'All guest or external accounts have a recorded successful sign-in.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Recent Successful ($(@($guestSummary.RecentAccounts).Count))" {
+                            if (@($guestSummary.RecentAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Recently Active External Accounts' {
+                                    New-HTMLTable -DataTable $guestSummary.RecentAccounts -Filtering $guestTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Recently Active External Accounts' {
+                                    New-HTMLText -Text 'No external accounts have a successful sign-in within the last 30 days.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Stale Successful ($(@($guestSummary.StaleAccounts).Count))" {
+                            if (@($guestSummary.StaleAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Stale External Accounts' {
+                                    New-HTMLTable -DataTable $guestSummary.StaleAccounts -Filtering $guestTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Stale External Accounts' {
+                                    New-HTMLText -Text 'No external accounts are currently stale based on successful sign-in activity.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Privileged ($(@($guestSummary.PrivilegedAccounts).Count))" {
+                            if (@($guestSummary.PrivilegedAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Privileged External Accounts' {
+                                    New-HTMLTable -DataTable $guestSummary.PrivilegedAccounts -Filtering $guestTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Privileged External Accounts' {
+                                    New-HTMLText -Text 'No guest or external accounts currently hold directory roles.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Licensed ($(@($guestSummary.LicensedAccounts).Count))" {
+                            if (@($guestSummary.LicensedAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Licensed External Accounts' {
+                                    New-HTMLTable -DataTable $guestSummary.LicensedAccounts -Filtering $guestTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Licensed External Accounts' {
+                                    New-HTMLText -Text 'No guest or external accounts currently have licenses assigned.' -Color Orange
                                 }
                             }
                         }

--- a/Private/Configuration.Users.ps1
+++ b/Private/Configuration.Users.ps1
@@ -20,12 +20,18 @@ $Script:Users = [ordered] @{
         $usersWithoutLicenses = 0
         $usersWithoutManager = 0
         $neverSignedInUsers = 0
+        $neverSuccessfulSignInUsers = 0
         $inactiveUsers = 0
         $recentUsers = 0
+        $inactiveSuccessfulUsers = 0
+        $recentSuccessfulUsers = 0
         $domainCounts = @{}
         $userTypeCounts = @{}
+        $cloudOnlyProfileCounts = @{}
         $memberAccounts = [System.Collections.Generic.List[object]]::new()
         $guestAccounts = [System.Collections.Generic.List[object]]::new()
+        $cloudOnlyMemberAccounts = [System.Collections.Generic.List[object]]::new()
+        $cloudOnlyReviewQueue = [System.Collections.Generic.List[object]]::new()
         $reviewCandidates = [System.Collections.Generic.List[object]]::new()
 
         foreach ($user in $userData) {
@@ -69,6 +75,10 @@ $Script:Users = [ordered] @{
                 $neverSignedInUsers++
             }
 
+            if ($user.NeverSuccessfullySignedIn -eq $true) {
+                $neverSuccessfulSignInUsers++
+            }
+
             if (($null -ne $user.LastSignInDaysAgo -and $user.LastSignInDaysAgo -gt 90) -or ($null -ne $user.LastNonInteractiveSignInDaysAgo -and $user.LastNonInteractiveSignInDaysAgo -gt 90)) {
                 $inactiveUsers++
             }
@@ -77,11 +87,33 @@ $Script:Users = [ordered] @{
                 $recentUsers++
             }
 
+            if ($null -ne $user.LastSuccessfulSignInDaysAgo -and $user.LastSuccessfulSignInDaysAgo -gt 90) {
+                $inactiveSuccessfulUsers++
+            }
+
+            if ($null -ne $user.LastSuccessfulSignInDaysAgo -and $user.LastSuccessfulSignInDaysAgo -le 30) {
+                $recentSuccessfulUsers++
+            }
+
             if ($user.UserDomain) {
                 if (-not $domainCounts.ContainsKey($user.UserDomain)) {
                     $domainCounts[$user.UserDomain] = 0
                 }
                 $domainCounts[$user.UserDomain]++
+            }
+
+            if ($user.IsCloudOnlyMemberCandidate) {
+                $cloudOnlyMemberAccounts.Add($user)
+
+                $cloudOnlyProfile = if ($user.CloudOnlyProfile) { $user.CloudOnlyProfile } else { 'Not classified' }
+                if (-not $cloudOnlyProfileCounts.ContainsKey($cloudOnlyProfile)) {
+                    $cloudOnlyProfileCounts[$cloudOnlyProfile] = 0
+                }
+                $cloudOnlyProfileCounts[$cloudOnlyProfile]++
+
+                if ($user.CloudOnlyReviewPriority -in @('High', 'Medium')) {
+                    $cloudOnlyReviewQueue.Add($user)
+                }
             }
 
             $reviewFlags = [System.Collections.Generic.List[string]]::new()
@@ -97,8 +129,14 @@ $Script:Users = [ordered] @{
             if ($user.NeverSignedIn -eq $true) {
                 $reviewFlags.Add('Never signed in')
             }
+            if ($user.NeverSuccessfullySignedIn -eq $true) {
+                $reviewFlags.Add('No successful sign-in')
+            }
             if (($null -ne $user.LastSignInDaysAgo -and $user.LastSignInDaysAgo -gt 90) -or ($null -ne $user.LastNonInteractiveSignInDaysAgo -and $user.LastNonInteractiveSignInDaysAgo -gt 90)) {
                 $reviewFlags.Add('Inactive 90+ days')
+            }
+            if ($null -ne $user.LastSuccessfulSignInDaysAgo -and $user.LastSuccessfulSignInDaysAgo -gt 90) {
+                $reviewFlags.Add('No successful sign-in 90+ days')
             }
             if ($null -ne $user.LastPasswordChangeDays -and $user.LastPasswordChangeDays -gt 180) {
                 $reviewFlags.Add('Password older than 180 days')
@@ -108,6 +146,12 @@ $Script:Users = [ordered] @{
             }
             if ($user.LicensesStatus -contains 'Error') {
                 $reviewFlags.Add('License issue')
+            }
+            if ($user.IsCloudOnlyMemberCandidate -and $user.CloudOnlyProfile -eq 'Likely human account') {
+                $reviewFlags.Add('Cloud-only member with human usage pattern')
+            }
+            if ($user.IsCloudOnlyMemberCandidate -and $user.CloudOnlyProfile -eq 'Needs review') {
+                $reviewFlags.Add('Cloud-only member requires classification review')
             }
 
             if ($reviewFlags.Count -gt 0) {
@@ -129,8 +173,15 @@ $Script:Users = [ordered] @{
                 UnlicensedUsers    = $usersWithoutLicenses
                 UsersWithoutManager = $usersWithoutManager
                 NeverSignedIn      = $neverSignedInUsers
+                NeverSuccessfulSignIn = $neverSuccessfulSignInUsers
                 Inactive90Days     = $inactiveUsers
                 Active30Days       = $recentUsers
+                InactiveSuccessful90Days = $inactiveSuccessfulUsers
+                ActiveSuccessful30Days = $recentSuccessfulUsers
+                CloudOnlyMemberCandidates = $cloudOnlyMemberAccounts.Count
+                CloudOnlyLikelyHuman = @($cloudOnlyMemberAccounts.Where({ $_.CloudOnlyProfile -eq 'Likely human account' })).Count
+                CloudOnlyLikelyWorkload = @($cloudOnlyMemberAccounts.Where({ $_.CloudOnlyProfile -eq 'Likely workload/resource' })).Count
+                CloudOnlyNeedsReview = @($cloudOnlyMemberAccounts.Where({ $_.CloudOnlyProfile -eq 'Needs review' })).Count
             }
         )
 
@@ -161,6 +212,15 @@ $Script:Users = [ordered] @{
             [PSCustomObject]@{ Name = '180+ days'; Count = @($userData.Where({ ($null -ne $_.LastSignInDaysAgo -and $_.LastSignInDaysAgo -gt 180) -or ($null -ne $_.LastNonInteractiveSignInDaysAgo -and $_.LastNonInteractiveSignInDaysAgo -gt 180) })).Count }
         )
 
+        $successfulSignInDistribution = @(
+            [PSCustomObject]@{ Name = 'No activity data'; Count = @($userData.Where({ $null -eq $_.NeverSuccessfullySignedIn -and $null -eq $_.LastSuccessfulSignInDaysAgo })).Count }
+            [PSCustomObject]@{ Name = 'No successful sign-in'; Count = @($userData.Where({ $_.NeverSuccessfullySignedIn -eq $true })).Count }
+            [PSCustomObject]@{ Name = '0-30 days'; Count = @($userData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -le 30 })).Count }
+            [PSCustomObject]@{ Name = '31-90 days'; Count = @($userData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 30 -and $_.LastSuccessfulSignInDaysAgo -le 90 })).Count }
+            [PSCustomObject]@{ Name = '91-180 days'; Count = @($userData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 90 -and $_.LastSuccessfulSignInDaysAgo -le 180 })).Count }
+            [PSCustomObject]@{ Name = '180+ days'; Count = @($userData.Where({ $null -ne $_.LastSuccessfulSignInDaysAgo -and $_.LastSuccessfulSignInDaysAgo -gt 180 })).Count }
+        )
+
         $identitySourceDistribution = @(
             [PSCustomObject]@{ Name = 'Synchronized'; Count = $synchronizedUsers }
             [PSCustomObject]@{ Name = 'Cloud only'; Count = $cloudOnlyUsers }
@@ -173,15 +233,28 @@ $Script:Users = [ordered] @{
             [PSCustomObject]@{ Name = 'License issues'; Count = @($userData.Where({ $_.LicensesStatus -contains 'Error' })).Count }
         )
 
+        $cloudOnlyProfileDistribution = @(
+            foreach ($key in $cloudOnlyProfileCounts.Keys) {
+                [PSCustomObject]@{
+                    Name  = $key
+                    Count = $cloudOnlyProfileCounts[$key]
+                }
+            }
+        ) | Sort-Object Count -Descending
+
         [PSCustomObject]@{
             Overview                   = $overview
             DomainDistribution         = $domainDistribution
             UserTypeDistribution       = $userTypeDistribution
             SignInDistribution         = $signInDistribution
+            SuccessfulSignInDistribution = $successfulSignInDistribution
             IdentitySourceDistribution = $identitySourceDistribution
             LicenseDistribution        = $licenseDistribution
+            CloudOnlyProfileDistribution = $cloudOnlyProfileDistribution
             MemberAccounts             = @($memberAccounts)
             GuestAccounts              = @($guestAccounts)
+            CloudOnlyMemberAccounts    = @($cloudOnlyMemberAccounts)
+            CloudOnlyReviewQueue       = @($cloudOnlyReviewQueue)
             ReviewCandidates           = @($reviewCandidates)
         }
     }
@@ -215,6 +288,10 @@ $Script:Users = [ordered] @{
                 New-HTMLTableCondition -Name 'LicensesStatus' -Operator eq -Value '' -ComparisonType string -BackgroundColor OldGold
 
                 New-HTMLTableCondition -Name 'NeverSignedIn' -Operator eq -Value $true -ComparisonType string -BackgroundColor PeachOrange -HighlightHeaders 'NeverSignedIn', 'LastSignInDateTime', 'LastNonInteractiveSignInDateTime'
+                New-HTMLTableCondition -Name 'NeverSuccessfullySignedIn' -Operator eq -Value $true -ComparisonType string -BackgroundColor CoralRed -HighlightHeaders 'NeverSuccessfullySignedIn', 'LastSuccessfulSignInDateTime'
+                New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Non-interactive only' -ComparisonType string -BackgroundColor LightSkyBlue -HighlightHeaders 'SignInPattern', 'LastNonInteractiveSignInDateTime'
+                New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Interactive only' -ComparisonType string -BackgroundColor LightGreen -HighlightHeaders 'SignInPattern', 'LastSignInDateTime'
+                New-HTMLTableCondition -Name 'SignInPattern' -Operator eq -Value 'Interactive + non-interactive' -ComparisonType string -BackgroundColor MediumSpringGreen -HighlightHeaders 'SignInPattern'
 
                 New-HTMLTableCondition -Name 'LastSignInDaysAgo' -Value 180 -Operator gt -ComparisonType number -BackgroundColor CoralRed -HighlightHeaders 'LastSignInDaysAgo', 'LastSignInDateTime'
                 New-HTMLTableCondition -Name 'LastSignInDaysAgo' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastSignInDaysAgo', 'LastSignInDateTime'
@@ -226,6 +303,11 @@ $Script:Users = [ordered] @{
                 New-HTMLTableCondition -Name 'LastNonInteractiveSignInDaysAgo' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastNonInteractiveSignInDaysAgo', 'LastNonInteractiveSignInDateTime'
                 New-HTMLTableCondition -Name 'LastNonInteractiveSignInDaysAgo' -Value 30 -Operator le -ComparisonType number -BackgroundColor MediumSpringGreen -HighlightHeaders 'LastNonInteractiveSignInDaysAgo', 'LastNonInteractiveSignInDateTime'
 
+                New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 180 -Operator gt -ComparisonType number -BackgroundColor CoralRed -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+                New-HTMLTableCondition -Name 'LastSuccessfulSignInDaysAgo' -Value 30 -Operator le -ComparisonType number -BackgroundColor MediumSpringGreen -HighlightHeaders 'LastSuccessfulSignInDaysAgo', 'LastSuccessfulSignInDateTime'
+
                 New-HTMLTableCondition -Name 'LastPasswordChangeDays' -Value 180 -Operator gt -ComparisonType number -BackgroundColor CoralRed -HighlightHeaders 'LastPasswordChangeDays', 'LastPasswordChangeDateTime'
                 New-HTMLTableCondition -Name 'LastPasswordChangeDays' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastPasswordChangeDays', 'LastPasswordChangeDateTime'
                 New-HTMLTableCondition -Name 'LastPasswordChangeDays' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastPasswordChangeDays', 'LastPasswordChangeDateTime'
@@ -235,6 +317,12 @@ $Script:Users = [ordered] @{
                 New-HTMLTableCondition -Name 'LastSynchronizedDays' -Value 180 -Operator le -ComparisonType number -BackgroundColor SunsetOrange -HighlightHeaders 'LastSynchronizedDays', 'LastSynchronized'
                 New-HTMLTableCondition -Name 'LastSynchronizedDays' -Value 90 -Operator le -ComparisonType number -BackgroundColor LaserLemon -HighlightHeaders 'LastSynchronizedDays', 'LastSynchronized'
                 New-HTMLTableCondition -Name 'LastSynchronizedDays' -Value 30 -Operator le -ComparisonType number -BackgroundColor MediumSpringGreen -HighlightHeaders 'LastSynchronizedDays', 'LastSynchronized'
+
+                New-HTMLTableCondition -Name 'CloudOnlyProfile' -Operator eq -Value 'Likely human account' -ComparisonType string -BackgroundColor Salmon -HighlightHeaders 'CloudOnlyProfile', 'CloudOnlySignals'
+                New-HTMLTableCondition -Name 'CloudOnlyProfile' -Operator eq -Value 'Needs review' -ComparisonType string -BackgroundColor OldGold -HighlightHeaders 'CloudOnlyProfile', 'CloudOnlySignals'
+                New-HTMLTableCondition -Name 'CloudOnlyProfile' -Operator eq -Value 'Likely workload/resource' -ComparisonType string -BackgroundColor LightSkyBlue -HighlightHeaders 'CloudOnlyProfile', 'CloudOnlySignals'
+                New-HTMLTableCondition -Name 'CloudOnlyReviewPriority' -Operator eq -Value 'High' -ComparisonType string -BackgroundColor CoralRed -HighlightHeaders 'CloudOnlyReviewPriority', 'CloudOnlyProfile'
+                New-HTMLTableCondition -Name 'CloudOnlyReviewPriority' -Operator eq -Value 'Medium' -ComparisonType string -BackgroundColor SunsetOrange -HighlightHeaders 'CloudOnlyReviewPriority', 'CloudOnlyProfile'
             }
 
             New-HTMLTabPanel {
@@ -251,8 +339,14 @@ $Script:Users = [ordered] @{
                             New-HTMLSection -Invisible {
                                 New-HTMLInfoCard -Title 'Synchronized / Cloud' -Number "$($overview.SynchronizedUsers) / $($overview.CloudOnlyUsers)" -Subtitle 'Identity source split' -Icon '🔄' -IconColor '#fd7e14' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                                 New-HTMLInfoCard -Title 'Without Manager' -Number $overview.UsersWithoutManager -Subtitle 'Users missing manager assignment' -Icon '🧭' -IconColor '#dc3545' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
-                                New-HTMLInfoCard -Title 'Never Signed In' -Number $overview.NeverSignedIn -Subtitle 'Only when sign-in activity is available' -Icon '⏱️' -IconColor '#dc3545' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
-                                New-HTMLInfoCard -Title 'Inactive 90+ Days' -Number $overview.Inactive90Days -Subtitle 'No recent sign-in activity reported' -Icon '📉' -IconColor '#ffc107' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                                New-HTMLInfoCard -Title 'No Successful Sign-in' -Number $overview.NeverSuccessfulSignIn -Subtitle 'Interactive or non-interactive success not recorded' -Icon '⏱️' -IconColor '#dc3545' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                                New-HTMLInfoCard -Title 'Successful Inactive 90+ Days' -Number $overview.InactiveSuccessful90Days -Subtitle 'No recent successful sign-in recorded' -Icon '📉' -IconColor '#ffc107' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                            }
+                            New-HTMLSection -Invisible {
+                                New-HTMLInfoCard -Title 'Cloud-only Members' -Number $overview.CloudOnlyMemberCandidates -Subtitle 'Enabled member accounts that are not synchronized' -Icon '☁️' -IconColor '#0d6efd' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                                New-HTMLInfoCard -Title 'Likely Human / Workload' -Number "$($overview.CloudOnlyLikelyHuman) / $($overview.CloudOnlyLikelyWorkload)" -Subtitle 'Heuristic split for cloud-only members' -Icon '🧩' -IconColor '#6f42c1' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                                New-HTMLInfoCard -Title 'Needs Review' -Number $overview.CloudOnlyNeedsReview -Subtitle 'Cloud-only members without a clear pattern' -Icon '🔍' -IconColor '#fd7e14' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
+                                New-HTMLInfoCard -Title 'Successful Active 30 Days' -Number $overview.ActiveSuccessful30Days -Subtitle 'Users with recent successful sign-in activity' -Icon '📈' -IconColor '#198754' -Style 'Standard' -ShadowIntensity 'Normal' -BorderRadius 2px
                             }
                             New-HTMLSection -Invisible {
                                 New-HTMLPanel {
@@ -263,8 +357,8 @@ $Script:Users = [ordered] @{
                                     }
                                 }
                                 New-HTMLPanel {
-                                    New-HTMLChart -Title 'User Sign-in Recency' {
-                                        foreach ($item in $userSummary.SignInDistribution) {
+                                    New-HTMLChart -Title 'Successful Sign-in Recency' {
+                                        foreach ($item in $userSummary.SuccessfulSignInDistribution) {
                                             New-ChartPie -Name $item.Name -Value $item.Count
                                         }
                                     }
@@ -279,8 +373,24 @@ $Script:Users = [ordered] @{
                                     }
                                 }
                                 New-HTMLPanel {
+                                    New-HTMLChart -Title 'Cloud-only Member Profiles' {
+                                        foreach ($item in $userSummary.CloudOnlyProfileDistribution) {
+                                            New-ChartPie -Name $item.Name -Value $item.Count
+                                        }
+                                    }
+                                }
+                            }
+                            New-HTMLSection -HeaderText 'Identity Signals' -Invisible {
+                                New-HTMLPanel {
                                     New-HTMLChart -Title 'License Coverage' {
                                         foreach ($item in $userSummary.LicenseDistribution) {
+                                            New-ChartPie -Name $item.Name -Value $item.Count
+                                        }
+                                    }
+                                }
+                                New-HTMLPanel {
+                                    New-HTMLChart -Title 'User Sign-in Recency' {
+                                        foreach ($item in $userSummary.SignInDistribution) {
                                             New-ChartPie -Name $item.Name -Value $item.Count
                                         }
                                     }
@@ -328,6 +438,28 @@ $Script:Users = [ordered] @{
                             } else {
                                 New-HTMLSection -HeaderText 'Guest And External Accounts' {
                                     New-HTMLText -Text 'No guest or external accounts found in the user dataset.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Cloud-only Members ($(@($userSummary.CloudOnlyMemberAccounts).Count))" {
+                            if (@($userSummary.CloudOnlyMemberAccounts).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Enabled Cloud-only Member Accounts' {
+                                    New-HTMLTable -DataTable $userSummary.CloudOnlyMemberAccounts -Filtering $userTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Enabled Cloud-only Member Accounts' {
+                                    New-HTMLText -Text 'No enabled cloud-only member accounts were detected in the current dataset.' -Color Orange
+                                }
+                            }
+                        }
+                        New-HTMLTab -Name "Cloud-only Review ($(@($userSummary.CloudOnlyReviewQueue).Count))" {
+                            if (@($userSummary.CloudOnlyReviewQueue).Count -gt 0) {
+                                New-HTMLSection -HeaderText 'Cloud-only Member Review Queue' {
+                                    New-HTMLTable -DataTable $userSummary.CloudOnlyReviewQueue -Filtering $userTableConditions -ScrollX
+                                }
+                            } else {
+                                New-HTMLSection -HeaderText 'Cloud-only Member Review Queue' {
+                                    New-HTMLText -Text 'No cloud-only member accounts currently require classification review.' -Color Orange
                                 }
                             }
                         }

--- a/Private/New-MyUserAuthenticationObject.ps1
+++ b/Private/New-MyUserAuthenticationObject.ps1
@@ -42,6 +42,8 @@ function New-MyUserAuthenticationObject {
         LastSignInDaysAgo                = if ($User.SignInActivity -and $User.SignInActivity.LastSignInDateTime) { [math]::Round((New-TimeSpan -Start $User.SignInActivity.LastSignInDateTime -End $Today).TotalDays, 0) } else { $null }
         LastNonInteractiveSignInDateTime = if ($User.SignInActivity) { $User.SignInActivity.LastNonInteractiveSignInDateTime } else { $null }
         LastNonInteractiveSignInDaysAgo  = if ($User.SignInActivity -and $User.SignInActivity.LastNonInteractiveSignInDateTime) { [math]::Round((New-TimeSpan -Start $User.SignInActivity.LastNonInteractiveSignInDateTime -End $Today).TotalDays, 0) } else { $null }
+        LastSuccessfulSignInDateTime     = if ($User.SignInActivity) { $User.SignInActivity.LastSuccessfulSignInDateTime } else { $null }
+        LastSuccessfulSignInDaysAgo      = if ($User.SignInActivity -and $User.SignInActivity.LastSuccessfulSignInDateTime) { [math]::Round((New-TimeSpan -Start $User.SignInActivity.LastSuccessfulSignInDateTime -End $Today).TotalDays, 0) } else { $null }
 
         # Authentication Status
         DefaultMfaMethod                 = $defaultMfaMethod

--- a/Public/Get-MyGuest.ps1
+++ b/Public/Get-MyGuest.ps1
@@ -81,6 +81,26 @@ function Get-MyGuest {
             $LastNonInteractiveSignInDaysAgo = $null
         }
 
+        if ($Guest.SignInActivity -and $Guest.SignInActivity.LastSuccessfulSignInDateTime) {
+            $LastSuccessfulSignInDaysAgo = [math]::Floor((New-TimeSpan -Start $Guest.SignInActivity.LastSuccessfulSignInDateTime -End $Today).TotalDays)
+        } else {
+            $LastSuccessfulSignInDaysAgo = $null
+        }
+
+        if ($null -ne $LastSignInDaysAgo -and $null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Interactive + non-interactive'
+        } elseif ($null -ne $LastSignInDaysAgo) {
+            $SignInPattern = 'Interactive only'
+        } elseif ($null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Non-interactive only'
+        } elseif ($null -ne $LastSuccessfulSignInDaysAgo) {
+            $SignInPattern = 'Successful sign-in only'
+        } elseif ($Guest.SignInActivity) {
+            $SignInPattern = 'No sign-in recorded'
+        } else {
+            $SignInPattern = 'No activity data'
+        }
+
         $ExternalAddress = $null
         if ($Guest.OtherMails -and $Guest.OtherMails.Count -gt 0) {
             $ExternalAddress = $Guest.OtherMails[0]
@@ -155,7 +175,11 @@ function Get-MyGuest {
             LastSignInDaysAgo                 = $LastSignInDaysAgo
             LastNonInteractiveSignInDateTime  = if ($Guest.SignInActivity) { $Guest.SignInActivity.LastNonInteractiveSignInDateTime } else { $null }
             LastNonInteractiveSignInDaysAgo   = $LastNonInteractiveSignInDaysAgo
+            LastSuccessfulSignInDateTime      = if ($Guest.SignInActivity) { $Guest.SignInActivity.LastSuccessfulSignInDateTime } else { $null }
+            LastSuccessfulSignInDaysAgo       = $LastSuccessfulSignInDaysAgo
             NeverSignedIn                     = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            NeverSuccessfullySignedIn         = ($null -eq $LastSuccessfulSignInDaysAgo)
+            SignInPattern                     = $SignInPattern
             CreationType                      = $Guest.CreationType
             CompanyName                       = $Guest.CompanyName
             IsSynchronized                    = if ($Guest.OnPremisesSyncEnabled) { $Guest.OnPremisesSyncEnabled } else { $null }

--- a/Public/Get-MyGuest.ps1
+++ b/Public/Get-MyGuest.ps1
@@ -156,6 +156,14 @@ function Get-MyGuest {
             }
         }
 
+        if ($null -ne $Guest.SignInActivity) {
+            $NeverSignedIn = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            $NeverSuccessfullySignedIn = ($null -eq $LastSuccessfulSignInDaysAgo)
+        } else {
+            $NeverSignedIn = $null
+            $NeverSuccessfullySignedIn = $null
+        }
+
         [PSCustomObject] @{
             DisplayName                       = $Guest.DisplayName
             Id                                = $Guest.Id
@@ -177,8 +185,8 @@ function Get-MyGuest {
             LastNonInteractiveSignInDaysAgo   = $LastNonInteractiveSignInDaysAgo
             LastSuccessfulSignInDateTime      = if ($Guest.SignInActivity) { $Guest.SignInActivity.LastSuccessfulSignInDateTime } else { $null }
             LastSuccessfulSignInDaysAgo       = $LastSuccessfulSignInDaysAgo
-            NeverSignedIn                     = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
-            NeverSuccessfullySignedIn         = ($null -eq $LastSuccessfulSignInDaysAgo)
+            NeverSignedIn                     = $NeverSignedIn
+            NeverSuccessfullySignedIn         = $NeverSuccessfullySignedIn
             SignInPattern                     = $SignInPattern
             CreationType                      = $Guest.CreationType
             CompanyName                       = $Guest.CompanyName

--- a/Public/Get-MyUser.ps1
+++ b/Public/Get-MyUser.ps1
@@ -257,14 +257,18 @@ function Get-MyUser {
             $OutputUser['Licenses'] = $LicensesList
             $OutputUser['Plans'] = $Plans
 
-            $IsCloudOnlyMemberCandidate = $User.AccountEnabled -eq $true -and $User.UserType -eq 'Member' -and $User.OnPremisesSyncEnabled -eq $false
+            $IsCloudOnlyMemberCandidate = $User.AccountEnabled -eq $true -and $User.UserType -eq 'Member' -and $User.OnPremisesSyncEnabled -ne $true
             $CloudOnlyProfile = $null
             $CloudOnlyReviewPriority = $null
             $CloudOnlySignals = [System.Collections.Generic.List[string]]::new()
 
             if ($IsCloudOnlyMemberCandidate) {
                 $CloudOnlySignals.Add('Enabled member account')
-                $CloudOnlySignals.Add('Cloud-only identity source')
+                if ($null -eq $User.OnPremisesSyncEnabled) {
+                    $CloudOnlySignals.Add('Sync state unavailable, treated as cloud-only candidate')
+                } else {
+                    $CloudOnlySignals.Add('Cloud-only identity source')
+                }
 
                 if ($User.Manager.Id) {
                     $CloudOnlySignals.Add('Manager assigned')

--- a/Public/Get-MyUser.ps1
+++ b/Public/Get-MyUser.ps1
@@ -97,10 +97,32 @@ function Get-MyUser {
             $LastNonInteractiveSignInDaysAgo = $null
         }
 
+        if ($User.SignInActivity -and $User.SignInActivity.LastSuccessfulSignInDateTime) {
+            $LastSuccessfulSignInDaysAgo = [math]::Floor((New-TimeSpan -Start $User.SignInActivity.LastSuccessfulSignInDateTime -End $Today).TotalDays)
+        } else {
+            $LastSuccessfulSignInDaysAgo = $null
+        }
+
         if ($null -ne $User.SignInActivity) {
             $NeverSignedIn = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            $NeverSuccessfullySignedIn = ($null -eq $LastSuccessfulSignInDaysAgo)
         } else {
             $NeverSignedIn = $null
+            $NeverSuccessfullySignedIn = $null
+        }
+
+        if ($null -ne $LastSignInDaysAgo -and $null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Interactive + non-interactive'
+        } elseif ($null -ne $LastSignInDaysAgo) {
+            $SignInPattern = 'Interactive only'
+        } elseif ($null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Non-interactive only'
+        } elseif ($null -ne $LastSuccessfulSignInDaysAgo) {
+            $SignInPattern = 'Successful sign-in only'
+        } elseif ($null -ne $User.SignInActivity) {
+            $SignInPattern = 'No sign-in recorded'
+        } else {
+            $SignInPattern = 'No activity data'
         }
 
         $UserDomain = $null
@@ -138,7 +160,11 @@ function Get-MyUser {
             LastSignInDaysAgo                = $LastSignInDaysAgo
             LastNonInteractiveSignInDateTime = if ($User.SignInActivity) { $User.SignInActivity.LastNonInteractiveSignInDateTime } else { $null }
             LastNonInteractiveSignInDaysAgo  = $LastNonInteractiveSignInDaysAgo
+            LastSuccessfulSignInDateTime     = if ($User.SignInActivity) { $User.SignInActivity.LastSuccessfulSignInDateTime } else { $null }
+            LastSuccessfulSignInDaysAgo      = $LastSuccessfulSignInDaysAgo
             NeverSignedIn                    = $NeverSignedIn
+            NeverSuccessfullySignedIn        = $NeverSuccessfullySignedIn
+            SignInPattern                    = $SignInPattern
         }
 
         if ($PerLicense) {
@@ -230,6 +256,123 @@ function Get-MyUser {
             $OutputUser['LicensesErrors'] = $LicensesErrors
             $OutputUser['Licenses'] = $LicensesList
             $OutputUser['Plans'] = $Plans
+
+            $IsCloudOnlyMemberCandidate = $User.AccountEnabled -eq $true -and $User.UserType -eq 'Member' -and $User.OnPremisesSyncEnabled -eq $false
+            $CloudOnlyProfile = $null
+            $CloudOnlyReviewPriority = $null
+            $CloudOnlySignals = [System.Collections.Generic.List[string]]::new()
+
+            if ($IsCloudOnlyMemberCandidate) {
+                $CloudOnlySignals.Add('Enabled member account')
+                $CloudOnlySignals.Add('Cloud-only identity source')
+
+                if ($User.Manager.Id) {
+                    $CloudOnlySignals.Add('Manager assigned')
+                } else {
+                    $CloudOnlySignals.Add('No manager assigned')
+                }
+                if ($User.GivenName -or $User.SurName) {
+                    $CloudOnlySignals.Add('Given name or surname present')
+                } else {
+                    $CloudOnlySignals.Add('No given name or surname')
+                }
+                if ($User.JobTitle) {
+                    $CloudOnlySignals.Add('Job title present')
+                } else {
+                    $CloudOnlySignals.Add('No job title')
+                }
+                if ($null -ne $LastSignInDaysAgo) {
+                    $CloudOnlySignals.Add('Interactive sign-in observed')
+                }
+                if ($null -ne $LastNonInteractiveSignInDaysAgo -and $null -eq $LastSignInDaysAgo) {
+                    $CloudOnlySignals.Add('Only non-interactive sign-in observed')
+                }
+                if ($null -ne $LastSuccessfulSignInDaysAgo) {
+                    $CloudOnlySignals.Add("Successful sign-in recorded $LastSuccessfulSignInDaysAgo days ago")
+                } elseif ($NeverSuccessfullySignedIn -eq $true) {
+                    $CloudOnlySignals.Add('No successful sign-in recorded')
+                }
+                if (-not $LicensesList.Count) {
+                    $CloudOnlySignals.Add('No licenses assigned')
+                }
+
+                $workloadLicenseKeywords = @(
+                    'teams rooms',
+                    'meeting room',
+                    'common area phone',
+                    'resource account',
+                    'virtual user'
+                )
+                $hasWorkloadLicenseIndicator = $false
+
+                foreach ($LicenseName in $LicensesList) {
+                    $licenseValue = [string] $LicenseName
+                    $licenseValueLower = $licenseValue.ToLowerInvariant()
+                    foreach ($keyword in $workloadLicenseKeywords) {
+                        if ($licenseValueLower -like "*$keyword*") {
+                            $hasWorkloadLicenseIndicator = $true
+                            $CloudOnlySignals.Add("Workload license: $licenseValue")
+                            break
+                        }
+                    }
+                    if ($hasWorkloadLicenseIndicator) {
+                        break
+                    }
+                }
+
+                if (-not $hasWorkloadLicenseIndicator) {
+                    foreach ($PlanName in $Plans) {
+                        if (-not $PlanName) {
+                            continue
+                        }
+
+                        $planValue = [string] $PlanName
+                        $planValueLower = $planValue.ToLowerInvariant()
+                        foreach ($keyword in $workloadLicenseKeywords) {
+                            if ($planValueLower -like "*$keyword*") {
+                                $hasWorkloadLicenseIndicator = $true
+                                $CloudOnlySignals.Add("Workload plan: $planValue")
+                                break
+                            }
+                        }
+                        if ($hasWorkloadLicenseIndicator) {
+                            break
+                        }
+                    }
+                }
+
+                $hasHumanIndicators = $false
+                if ($User.Manager.Id -or $User.GivenName -or $User.SurName -or $User.JobTitle -or $null -ne $LastSignInDaysAgo) {
+                    $hasHumanIndicators = $true
+                }
+
+                $hasWorkloadBehaviorIndicators = $null -eq $LastSignInDaysAgo -and
+                    $null -ne $LastNonInteractiveSignInDaysAgo -and
+                    -not $User.Manager.Id -and
+                    -not $User.GivenName -and
+                    -not $User.SurName -and
+                    -not $User.JobTitle
+
+                if ($hasWorkloadBehaviorIndicators) {
+                    $CloudOnlySignals.Add('Non-interactive-only activity with no manager or profile attributes')
+                }
+
+                if ($hasWorkloadLicenseIndicator -or $hasWorkloadBehaviorIndicators) {
+                    $CloudOnlyProfile = 'Likely workload/resource'
+                    $CloudOnlyReviewPriority = 'Low'
+                } elseif ($hasHumanIndicators -and -not $hasWorkloadLicenseIndicator) {
+                    $CloudOnlyProfile = 'Likely human account'
+                    $CloudOnlyReviewPriority = 'High'
+                } else {
+                    $CloudOnlyProfile = 'Needs review'
+                    $CloudOnlyReviewPriority = 'Medium'
+                }
+            }
+
+            $OutputUser['IsCloudOnlyMemberCandidate'] = $IsCloudOnlyMemberCandidate
+            $OutputUser['CloudOnlyProfile'] = $CloudOnlyProfile
+            $OutputUser['CloudOnlyReviewPriority'] = $CloudOnlyReviewPriority
+            $OutputUser['CloudOnlySignals'] = if ($CloudOnlySignals.Count -gt 0) { $CloudOnlySignals -join ', ' } else { $null }
         }
 
         [PSCustomObject] $OutputUser


### PR DESCRIPTION
## Summary
Improve the user and guest reporting views so guest, external, and cloud-only accounts are easier to identify, sort, and review.

## What Changed
- add successful sign-in fields and sign-in pattern cues to the user and guest datasets
- expand the Users report with clearer cloud-only member review slices and successful sign-in summaries
- expand the Guests report with stronger external-account confirmation views, including no-successful-sign-in, recent, stale, privileged, and licensed tabs

## Why
The existing reporting made it harder to distinguish cloud-only member accounts from guest or external identities and to quickly confirm which external accounts exist and how recently they were actually used.

## Impact
- faster review of cloud-only member accounts that may need follow-up
- better confirmation of which guest and external accounts exist in the tenant
- easier sorting and filtering for stale, privileged, licensed, and never-successful external identities

## Validation
- PowerShell parser checks passed for the updated reporting files
- verified git diff scope before staging and publishing
