### PR TITLE
Add device lifecycle action helpers

### DIFF
--- a/GraphEssentials.psd1
+++ b/GraphEssentials.psd1
@@ -6,9 +6,9 @@
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'GraphEssentials is a PowerShell module that helps with Office 365 / Azure AD using mostly Graph'
-    FunctionsToExport    = @('Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
+    FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
     GUID                 = '75ef812f-6d8e-4898-81bb-8029e0560ef3'
-    ModuleVersion        = '0.0.55'
+    ModuleVersion        = '0.0.56'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Resolve-MyDeviceActionTarget.ps1
+++ b/Private/Resolve-MyDeviceActionTarget.ps1
@@ -1,0 +1,75 @@
+function Resolve-MyDeviceActionTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [PSObject] $InputObject,
+
+        [Parameter()]
+        [string] $EntraDeviceObjectId,
+
+        [Parameter()]
+        [string] $ManagedDeviceId,
+
+        [Parameter()]
+        [ValidateSet('Entra', 'Intune')]
+        [string] $TargetType
+    )
+
+    $resolvedEntraDeviceObjectId = $EntraDeviceObjectId
+    $resolvedManagedDeviceId = $ManagedDeviceId
+    $resolvedDisplayName = $null
+    $resolvedDeviceId = $null
+
+    if ($InputObject) {
+        if ($InputObject.PSObject.Properties['Name']) {
+            $resolvedDisplayName = $InputObject.Name
+        } elseif ($InputObject.PSObject.Properties['DisplayName']) {
+            $resolvedDisplayName = $InputObject.DisplayName
+        } elseif ($InputObject.PSObject.Properties['ManagedDeviceName']) {
+            $resolvedDisplayName = $InputObject.ManagedDeviceName
+        }
+
+        if (-not $resolvedEntraDeviceObjectId -and $InputObject.PSObject.Properties['EntraDeviceObjectId']) {
+            $resolvedEntraDeviceObjectId = $InputObject.EntraDeviceObjectId
+        }
+
+        if (-not $resolvedManagedDeviceId -and $InputObject.PSObject.Properties['ManagedDeviceId']) {
+            $resolvedManagedDeviceId = $InputObject.ManagedDeviceId
+        }
+
+        if (-not $resolvedManagedDeviceId -and
+            $InputObject.PSObject.Properties['AzureAdDeviceId'] -and
+            $InputObject.PSObject.Properties['Id']) {
+            $resolvedManagedDeviceId = $InputObject.Id
+        }
+
+        if ($InputObject.PSObject.Properties['DeviceId']) {
+            $resolvedDeviceId = $InputObject.DeviceId
+        } elseif ($InputObject.PSObject.Properties['AzureAdDeviceId']) {
+            $resolvedDeviceId = $InputObject.AzureAdDeviceId
+        }
+    }
+
+    if (-not $resolvedDisplayName) {
+        if ($TargetType -eq 'Entra' -and $resolvedEntraDeviceObjectId) {
+            $resolvedDisplayName = $resolvedEntraDeviceObjectId
+        } elseif ($TargetType -eq 'Intune' -and $resolvedManagedDeviceId) {
+            $resolvedDisplayName = $resolvedManagedDeviceId
+        }
+    }
+
+    if ($TargetType -eq 'Entra' -and -not $resolvedEntraDeviceObjectId) {
+        throw "Resolve-MyDeviceActionTarget - Unable to resolve Entra device object id."
+    }
+
+    if ($TargetType -eq 'Intune' -and -not $resolvedManagedDeviceId) {
+        throw "Resolve-MyDeviceActionTarget - Unable to resolve Intune managed device id."
+    }
+
+    [PSCustomObject] @{
+        DisplayName         = $resolvedDisplayName
+        EntraDeviceObjectId = $resolvedEntraDeviceObjectId
+        ManagedDeviceId     = $resolvedManagedDeviceId
+        DeviceId            = $resolvedDeviceId
+    }
+}

--- a/Public/Disable-MyDevice.ps1
+++ b/Public/Disable-MyDevice.ps1
@@ -1,0 +1,78 @@
+function Disable-MyDevice {
+    <#
+    .SYNOPSIS
+    Disables a Microsoft Entra device.
+
+    .DESCRIPTION
+    Disables a Microsoft Entra device by setting AccountEnabled to false.
+    The function accepts either a device object returned by GraphEssentials cmdlets
+    or an explicit Entra device object id.
+
+    .PARAMETER InputObject
+    Device object returned by Get-MyDevice, Get-MyDeviceIntune, or another object
+    that exposes EntraDeviceObjectId.
+
+    .PARAMETER EntraDeviceObjectId
+    The Microsoft Entra device object id to disable.
+
+    .EXAMPLE
+    Get-MyDevice -Type 'AzureAD registered' | Disable-MyDevice -WhatIf
+
+    .EXAMPLE
+    Disable-MyDevice -EntraDeviceObjectId '00000000-0000-0000-0000-000000000000'
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'ByObject')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string] $EntraDeviceObjectId
+    )
+
+    process {
+        try {
+            $resolvedTarget = Resolve-MyDeviceActionTarget -InputObject $InputObject -EntraDeviceObjectId $EntraDeviceObjectId -TargetType 'Entra'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Disable-MyDevice'
+            Write-Error -Message $errorInfo.FullMessage
+            return
+        }
+
+        $output = [ordered] @{
+            Action              = 'DisableEntraDevice'
+            DisplayName         = $resolvedTarget.DisplayName
+            EntraDeviceObjectId = $resolvedTarget.EntraDeviceObjectId
+            ManagedDeviceId     = $resolvedTarget.ManagedDeviceId
+            DeviceId            = $resolvedTarget.DeviceId
+            Success             = $false
+            Message             = $null
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($resolvedTarget.DisplayName, 'Disable Microsoft Entra device')) {
+            $output.Message = 'Operation skipped by ShouldProcess.'
+            [PSCustomObject] $output
+            return
+        }
+
+        try {
+            $updateMgDeviceSplat = @{
+                DeviceId      = $resolvedTarget.EntraDeviceObjectId
+                BodyParameter = @{
+                    accountEnabled = $false
+                }
+                ErrorAction   = 'Stop'
+            }
+            Update-MgDevice @updateMgDeviceSplat | Out-Null
+
+            $output.Success = $true
+            $output.Message = 'Device disabled successfully.'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Disable-MyDevice'
+            $output.Message = $errorInfo.Message
+            Write-Error -Message $errorInfo.FullMessage
+        }
+
+        [PSCustomObject] $output
+    }
+}

--- a/Public/Get-MyDevice.ps1
+++ b/Public/Get-MyDevice.ps1
@@ -104,6 +104,7 @@
         [PSCustomObject] @{
             Name                   = $Device.DisplayName
             Id                     = $Device.Id
+            EntraDeviceObjectId    = $Device.Id
             Enabled                = $Device.AccountEnabled
             OperatingSystem        = $Device.OperatingSystem
             OperatingSystemVersion = $Device.OperatingSystemVersion

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -74,8 +74,8 @@
         try {
             $DevicesAzure = Get-MgDevice -All -Property 'deviceId,id' -ErrorAction Stop
         } catch {
-            Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure device identifiers. Error: $($_.Exception.Message)"
-            return
+            Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure device identifiers. Continuing without Entra device object IDs. Error: $($_.Exception.Message)"
+            $DevicesAzure = @()
         }
     }
 

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -60,7 +60,7 @@
     if ($Type -or $Synchronized) {
         try {
             if (-not $Script:Devices -or $Force -or $Script:DevicesDate -lt (Get-Date).AddMinutes(-$CacheMinutes)) {
-                $DevicesAzure = Get-MgDevice -All -Property 'deviceId,onPremisesSyncEnabled,trustType' -ErrorAction Stop
+                $DevicesAzure = Get-MgDevice -All -Property 'deviceId,id,onPremisesSyncEnabled,trustType' -ErrorAction Stop
             } else {
                 $DevicesAzure = $Script:Devices
             }

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -28,11 +28,15 @@
     .NOTES
     This function requires the Microsoft.Graph.Authentication module and appropriate permissions to access Intune data.
 
-    When you use Type parameter or Synchronized parameter, the function will retrieve Azure devices to match them with Intune devices.
+    The function always resolves Azure device object IDs so the output can be used with
+    lifecycle cmdlets such as Disable-MyDevice and Remove-MyDevice.
+
+    When you use Type parameter or Synchronized parameter, the function also retrieves
+    Azure trust and synchronization metadata to match and filter Intune devices.
     This operation may take some time, especially if you have a large number of devices.
-    That's why the function tries to use cached Azure devices if they were already retrieved by Get-MyDevice cmdlet.
-    If you want to force the function to retrieve Azure devices again, use the Force switch.
-    The cache is valid for 30 minutes by default.
+    That's why the function tries to use cached Azure devices if they were already retrieved
+    by Get-MyDevice cmdlet. If you want to force the function to retrieve Azure devices again,
+    use the Force switch. The cache is valid for 30 minutes by default.
     #>
     [cmdletBinding()]
     param(
@@ -51,8 +55,9 @@
         return
     }
 
+    # Always build a deviceId -> Entra object id lookup so lifecycle actions can
+    # resolve Microsoft Entra targets directly from Get-MyDeviceIntune output.
     if ($Type -or $Synchronized) {
-        # We only need to get Azure devices if we are filtering by type
         try {
             if (-not $Script:Devices -or $Force -or $Script:DevicesDate -lt (Get-Date).AddMinutes(-$CacheMinutes)) {
                 $DevicesAzure = Get-MgDevice -All -Property 'deviceId,onPremisesSyncEnabled,trustType' -ErrorAction Stop
@@ -63,10 +68,20 @@
             Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure devices. Error: $($_.Exception.Message)"
             return
         }
-        foreach ($DeviceA in $DevicesAzure) {
-            if ($DeviceA.DeviceId) {
-                $CachedAzure[$DeviceA.DeviceId] = $DeviceA
-            }
+    } elseif ($Script:Devices -and -not $Force -and $Script:DevicesDate -ge (Get-Date).AddMinutes(-$CacheMinutes)) {
+        $DevicesAzure = $Script:Devices
+    } else {
+        try {
+            $DevicesAzure = Get-MgDevice -All -Property 'deviceId,id' -ErrorAction Stop
+        } catch {
+            Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure device identifiers. Error: $($_.Exception.Message)"
+            return
+        }
+    }
+
+    foreach ($DeviceA in $DevicesAzure) {
+        if ($DeviceA.DeviceId) {
+            $CachedAzure[$DeviceA.DeviceId] = $DeviceA
         }
     }
 

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -136,6 +136,8 @@
         $DeviceInformation = [ordered] @{
             Name                                    = $DeviceI.DeviceName                                # : EVOMONSTER
             Id                                      = $DeviceI.Id                                        # : 83fe122f-c51c-49dc-a0f3-cc11d9e7d045
+            ManagedDeviceId                         = $DeviceI.Id
+            EntraDeviceObjectId                     = if ($DeviceA) { $DeviceA.Id } else { $null }
             ComplianceState                         = $DeviceI.ComplianceState                           # : compliant
             OperatingSystem                         = $DeviceI.OperatingSystem                           # : Windows
             OperatingSystemVersion                  = $DeviceI.OSVersion                                 # : 10.0.22621.1555

--- a/Public/Get-MyGuest.ps1
+++ b/Public/Get-MyGuest.ps1
@@ -81,6 +81,26 @@ function Get-MyGuest {
             $LastNonInteractiveSignInDaysAgo = $null
         }
 
+        if ($Guest.SignInActivity -and $Guest.SignInActivity.LastSuccessfulSignInDateTime) {
+            $LastSuccessfulSignInDaysAgo = [math]::Floor((New-TimeSpan -Start $Guest.SignInActivity.LastSuccessfulSignInDateTime -End $Today).TotalDays)
+        } else {
+            $LastSuccessfulSignInDaysAgo = $null
+        }
+
+        if ($null -ne $LastSignInDaysAgo -and $null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Interactive + non-interactive'
+        } elseif ($null -ne $LastSignInDaysAgo) {
+            $SignInPattern = 'Interactive only'
+        } elseif ($null -ne $LastNonInteractiveSignInDaysAgo) {
+            $SignInPattern = 'Non-interactive only'
+        } elseif ($null -ne $LastSuccessfulSignInDaysAgo) {
+            $SignInPattern = 'Successful sign-in only'
+        } elseif ($Guest.SignInActivity) {
+            $SignInPattern = 'No sign-in recorded'
+        } else {
+            $SignInPattern = 'No activity data'
+        }
+
         $ExternalAddress = $null
         if ($Guest.OtherMails -and $Guest.OtherMails.Count -gt 0) {
             $ExternalAddress = $Guest.OtherMails[0]
@@ -136,6 +156,14 @@ function Get-MyGuest {
             }
         }
 
+        if ($null -ne $Guest.SignInActivity) {
+            $NeverSignedIn = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            $NeverSuccessfullySignedIn = ($null -eq $LastSuccessfulSignInDaysAgo)
+        } else {
+            $NeverSignedIn = $null
+            $NeverSuccessfullySignedIn = $null
+        }
+
         [PSCustomObject] @{
             DisplayName                       = $Guest.DisplayName
             Id                                = $Guest.Id
@@ -155,7 +183,11 @@ function Get-MyGuest {
             LastSignInDaysAgo                 = $LastSignInDaysAgo
             LastNonInteractiveSignInDateTime  = if ($Guest.SignInActivity) { $Guest.SignInActivity.LastNonInteractiveSignInDateTime } else { $null }
             LastNonInteractiveSignInDaysAgo   = $LastNonInteractiveSignInDaysAgo
-            NeverSignedIn                     = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            LastSuccessfulSignInDateTime      = if ($Guest.SignInActivity) { $Guest.SignInActivity.LastSuccessfulSignInDateTime } else { $null }
+            LastSuccessfulSignInDaysAgo       = $LastSuccessfulSignInDaysAgo
+            NeverSignedIn                     = $NeverSignedIn
+            NeverSuccessfullySignedIn         = $NeverSuccessfullySignedIn
+            SignInPattern                     = $SignInPattern
             CreationType                      = $Guest.CreationType
             CompanyName                       = $Guest.CompanyName
             IsSynchronized                    = if ($Guest.OnPremisesSyncEnabled) { $Guest.OnPremisesSyncEnabled } else { $null }

--- a/Public/Get-MyGuest.ps1
+++ b/Public/Get-MyGuest.ps1
@@ -157,7 +157,7 @@ function Get-MyGuest {
         }
 
         if ($null -ne $Guest.SignInActivity) {
-            $NeverSignedIn = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo)
+            $NeverSignedIn = ($null -eq $LastSignInDaysAgo -and $null -eq $LastNonInteractiveSignInDaysAgo -and $null -eq $LastSuccessfulSignInDaysAgo)
             $NeverSuccessfullySignedIn = ($null -eq $LastSuccessfulSignInDaysAgo)
         } else {
             $NeverSignedIn = $null

--- a/Public/Invoke-MyDeviceRetire.ps1
+++ b/Public/Invoke-MyDeviceRetire.ps1
@@ -1,0 +1,75 @@
+function Invoke-MyDeviceRetire {
+    <#
+    .SYNOPSIS
+    Retires an Intune managed device.
+
+    .DESCRIPTION
+    Retires an Intune managed device using Microsoft Graph.
+    The function accepts either a device object returned by Get-MyDeviceIntune
+    or an explicit Intune managed device id.
+
+    .PARAMETER InputObject
+    Device object returned by Get-MyDeviceIntune or another object
+    that exposes ManagedDeviceId.
+
+    .PARAMETER ManagedDeviceId
+    The Intune managed device id to retire.
+
+    .EXAMPLE
+    Get-MyDeviceIntune -Type 'AzureAD registered' | Invoke-MyDeviceRetire -WhatIf
+
+    .EXAMPLE
+    Invoke-MyDeviceRetire -ManagedDeviceId '00000000-0000-0000-0000-000000000000'
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'ByObject')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string] $ManagedDeviceId
+    )
+
+    process {
+        try {
+            $resolvedTarget = Resolve-MyDeviceActionTarget -InputObject $InputObject -ManagedDeviceId $ManagedDeviceId -TargetType 'Intune'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Invoke-MyDeviceRetire'
+            Write-Error -Message $errorInfo.FullMessage
+            return
+        }
+
+        $output = [ordered] @{
+            Action              = 'RetireIntuneDevice'
+            DisplayName         = $resolvedTarget.DisplayName
+            EntraDeviceObjectId = $resolvedTarget.EntraDeviceObjectId
+            ManagedDeviceId     = $resolvedTarget.ManagedDeviceId
+            DeviceId            = $resolvedTarget.DeviceId
+            Success             = $false
+            Message             = $null
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($resolvedTarget.DisplayName, 'Retire Intune managed device')) {
+            $output.Message = 'Operation skipped by ShouldProcess.'
+            [PSCustomObject] $output
+            return
+        }
+
+        try {
+            $invokeMgRetireDeviceManagementManagedDeviceSplat = @{
+                ManagedDeviceId = $resolvedTarget.ManagedDeviceId
+                ErrorAction     = 'Stop'
+            }
+            Invoke-MgRetireDeviceManagementManagedDevice @invokeMgRetireDeviceManagementManagedDeviceSplat | Out-Null
+
+            $output.Success = $true
+            $output.Message = 'Managed device retired successfully.'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Invoke-MyDeviceRetire'
+            $output.Message = $errorInfo.Message
+            Write-Error -Message $errorInfo.FullMessage
+        }
+
+        [PSCustomObject] $output
+    }
+}

--- a/Public/Remove-MyDevice.ps1
+++ b/Public/Remove-MyDevice.ps1
@@ -1,0 +1,75 @@
+function Remove-MyDevice {
+    <#
+    .SYNOPSIS
+    Removes a Microsoft Entra device.
+
+    .DESCRIPTION
+    Deletes a Microsoft Entra device from the directory.
+    The function accepts either a device object returned by GraphEssentials cmdlets
+    or an explicit Entra device object id.
+
+    .PARAMETER InputObject
+    Device object returned by Get-MyDevice, Get-MyDeviceIntune, or another object
+    that exposes EntraDeviceObjectId.
+
+    .PARAMETER EntraDeviceObjectId
+    The Microsoft Entra device object id to remove.
+
+    .EXAMPLE
+    Get-MyDevice -Type 'AzureAD registered' | Remove-MyDevice -WhatIf
+
+    .EXAMPLE
+    Remove-MyDevice -EntraDeviceObjectId '00000000-0000-0000-0000-000000000000'
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'ByObject')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string] $EntraDeviceObjectId
+    )
+
+    process {
+        try {
+            $resolvedTarget = Resolve-MyDeviceActionTarget -InputObject $InputObject -EntraDeviceObjectId $EntraDeviceObjectId -TargetType 'Entra'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyDevice'
+            Write-Error -Message $errorInfo.FullMessage
+            return
+        }
+
+        $output = [ordered] @{
+            Action              = 'RemoveEntraDevice'
+            DisplayName         = $resolvedTarget.DisplayName
+            EntraDeviceObjectId = $resolvedTarget.EntraDeviceObjectId
+            ManagedDeviceId     = $resolvedTarget.ManagedDeviceId
+            DeviceId            = $resolvedTarget.DeviceId
+            Success             = $false
+            Message             = $null
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($resolvedTarget.DisplayName, 'Remove Microsoft Entra device')) {
+            $output.Message = 'Operation skipped by ShouldProcess.'
+            [PSCustomObject] $output
+            return
+        }
+
+        try {
+            $removeMgDeviceSplat = @{
+                DeviceId    = $resolvedTarget.EntraDeviceObjectId
+                ErrorAction = 'Stop'
+            }
+            Remove-MgDevice @removeMgDeviceSplat | Out-Null
+
+            $output.Success = $true
+            $output.Message = 'Device removed successfully.'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyDevice'
+            $output.Message = $errorInfo.Message
+            Write-Error -Message $errorInfo.FullMessage
+        }
+
+        [PSCustomObject] $output
+    }
+}

--- a/Public/Remove-MyDeviceIntuneRecord.ps1
+++ b/Public/Remove-MyDeviceIntuneRecord.ps1
@@ -1,0 +1,75 @@
+function Remove-MyDeviceIntuneRecord {
+    <#
+    .SYNOPSIS
+    Removes an Intune managed device record.
+
+    .DESCRIPTION
+    Deletes an Intune managed device record using Microsoft Graph.
+    The function accepts either a device object returned by Get-MyDeviceIntune
+    or an explicit Intune managed device id.
+
+    .PARAMETER InputObject
+    Device object returned by Get-MyDeviceIntune or another object
+    that exposes ManagedDeviceId.
+
+    .PARAMETER ManagedDeviceId
+    The Intune managed device id to remove.
+
+    .EXAMPLE
+    Get-MyDeviceIntune -Type 'AzureAD registered' | Remove-MyDeviceIntuneRecord -WhatIf
+
+    .EXAMPLE
+    Remove-MyDeviceIntuneRecord -ManagedDeviceId '00000000-0000-0000-0000-000000000000'
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'ByObject')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string] $ManagedDeviceId
+    )
+
+    process {
+        try {
+            $resolvedTarget = Resolve-MyDeviceActionTarget -InputObject $InputObject -ManagedDeviceId $ManagedDeviceId -TargetType 'Intune'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyDeviceIntuneRecord'
+            Write-Error -Message $errorInfo.FullMessage
+            return
+        }
+
+        $output = [ordered] @{
+            Action              = 'RemoveIntuneManagedDevice'
+            DisplayName         = $resolvedTarget.DisplayName
+            EntraDeviceObjectId = $resolvedTarget.EntraDeviceObjectId
+            ManagedDeviceId     = $resolvedTarget.ManagedDeviceId
+            DeviceId            = $resolvedTarget.DeviceId
+            Success             = $false
+            Message             = $null
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($resolvedTarget.DisplayName, 'Remove Intune managed device record')) {
+            $output.Message = 'Operation skipped by ShouldProcess.'
+            [PSCustomObject] $output
+            return
+        }
+
+        try {
+            $removeMgDeviceManagementManagedDeviceSplat = @{
+                ManagedDeviceId = $resolvedTarget.ManagedDeviceId
+                ErrorAction     = 'Stop'
+            }
+            Remove-MgDeviceManagementManagedDevice @removeMgDeviceManagementManagedDeviceSplat | Out-Null
+
+            $output.Success = $true
+            $output.Message = 'Managed device record removed successfully.'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyDeviceIntuneRecord'
+            $output.Message = $errorInfo.Message
+            Write-Error -Message $errorInfo.FullMessage
+        }
+
+        [PSCustomObject] $output
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -85,12 +85,16 @@ Complete list of commands available in GraphEssentials module.
 | Function    | Get-MyUsageReports               |
 | Function    | Get-MyUser                       |
 | Function    | Get-MyUserAuthentication         |
+| Function    | Disable-MyDevice                 |
+| Function    | Invoke-MyDeviceRetire            |
 | Function    | Invoke-MyGraphEssentials         |
 | Function    | Invoke-MyGraphUsageReports       |
 | Function    | New-MyApp                        |
 | Function    | New-MyAppCredentials             |
 | Function    | Register-FIDO2Key                |
 | Function    | Remove-MyAppCredentials          |
+| Function    | Remove-MyDevice                  |
+| Function    | Remove-MyDeviceIntuneRecord      |
 | Function    | Send-MyApp                       |
 | Function    | Show-MyApp                       |
 | Function    | Show-MyConditionalAccess         |

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -41,6 +41,25 @@ Describe 'Get-MyDeviceIntune' {
         $devices[0].EntraDeviceObjectId | Should -Be 'entra-1'
     }
 
+    It 'populates EntraDeviceObjectId on the filtered path' {
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceId             = 'device-1'
+                    Id                   = 'entra-1'
+                    TrustType            = 'Workplace'
+                    OnPremisesSyncEnabled = $false
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -Type 'AzureAD registered' -Force)
+
+        $devices.Count | Should -Be 1
+        $devices[0].EntraDeviceObjectId | Should -Be 'entra-1'
+        $devices[0].TrustType | Should -Be 'AzureAD registered'
+    }
+
     It 'continues Intune enumeration when the default Entra lookup fails' {
         Mock Get-MgDevice {
             throw 'Entra lookup failed'

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -1,5 +1,8 @@
 BeforeAll {
     . (Join-Path $PSScriptRoot '..\Public\Get-MyDeviceIntune.ps1')
+
+    function Get-MgDeviceManagementManagedDevice {}
+    function Get-MgDevice {}
 }
 
 Describe 'Get-MyDeviceIntune' {
@@ -18,7 +21,7 @@ Describe 'Get-MyDeviceIntune' {
                     OSVersion        = '17.0'
                 }
             )
-        } -ParameterFilter { $All }
+        }
 
         Mock Get-MgDevice {
             @(
@@ -31,10 +34,22 @@ Describe 'Get-MyDeviceIntune' {
     }
 
     It 'populates EntraDeviceObjectId on the default path' {
-        $devices = Get-MyDeviceIntune -Force
+        $devices = @(Get-MyDeviceIntune -Force)
 
         $devices.Count | Should -Be 1
         $devices[0].ManagedDeviceId | Should -Be 'managed-1'
         $devices[0].EntraDeviceObjectId | Should -Be 'entra-1'
+    }
+
+    It 'continues Intune enumeration when the default Entra lookup fails' {
+        Mock Get-MgDevice {
+            throw 'Entra lookup failed'
+        }
+
+        $devices = @(Get-MyDeviceIntune -Force)
+
+        $devices.Count | Should -Be 1
+        $devices[0].ManagedDeviceId | Should -Be 'managed-1'
+        $devices[0].EntraDeviceObjectId | Should -Be $null
     }
 }

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -1,0 +1,40 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Public\Get-MyDeviceIntune.ps1')
+}
+
+Describe 'Get-MyDeviceIntune' {
+    BeforeEach {
+        $script:Devices = $null
+        $script:DevicesDate = $null
+
+        Mock Get-MgDeviceManagementManagedDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceName       = 'iPhone-01'
+                    Id               = 'managed-1'
+                    AzureAdDeviceId  = 'device-1'
+                    LastSyncDateTime = (Get-Date).AddDays(-10)
+                    OperatingSystem  = 'iOS'
+                    OSVersion        = '17.0'
+                }
+            )
+        } -ParameterFilter { $All }
+
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceId = 'device-1'
+                    Id       = 'entra-1'
+                }
+            )
+        }
+    }
+
+    It 'populates EntraDeviceObjectId on the default path' {
+        $devices = Get-MyDeviceIntune -Force
+
+        $devices.Count | Should -Be 1
+        $devices[0].ManagedDeviceId | Should -Be 'managed-1'
+        $devices[0].EntraDeviceObjectId | Should -Be 'entra-1'
+    }
+}

--- a/Tests/Get-MyGuest.Tests.ps1
+++ b/Tests/Get-MyGuest.Tests.ps1
@@ -1,0 +1,63 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Public\Get-MyGuest.ps1')
+
+    function Get-MyLicense {}
+    function Get-MyUserRolesAndLicensesLookup {}
+    function Get-MgUser {}
+    function Stop-TimeLog {}
+}
+
+Describe 'Get-MyGuest' {
+    BeforeEach {
+        Mock Get-MyLicense {
+            @{
+                Licenses     = @{}
+                ServicePlans = @{}
+            }
+        }
+
+        Mock Get-MyUserRolesAndLicensesLookup {
+            @{
+                Roles = @{}
+            }
+        }
+
+        Mock Get-MgUser {
+            @(
+                [PSCustomObject] @{
+                    DisplayName                     = 'Guest One'
+                    Id                              = 'guest-1'
+                    UserPrincipalName               = 'guest.one#EXT#@contoso.onmicrosoft.com'
+                    Mail                            = 'guest.one@example.com'
+                    OtherMails                      = @()
+                    UserType                        = 'Guest'
+                    AccountEnabled                  = $true
+                    CreatedDateTime                 = (Get-Date).AddDays(-30)
+                    ExternalUserState               = 'Accepted'
+                    ExternalUserStateChangeDateTime = (Get-Date).AddDays(-29)
+                    SignInActivity                  = [PSCustomObject] @{
+                        LastSignInDateTime               = $null
+                        LastNonInteractiveSignInDateTime = $null
+                        LastSuccessfulSignInDateTime     = (Get-Date).AddDays(-3)
+                    }
+                    CreationType                    = 'Invitation'
+                    CompanyName                     = 'Example'
+                    OnPremisesSyncEnabled           = $null
+                    LicenseAssignmentStates         = @()
+                    AssignedPlans                   = @()
+                }
+            )
+        }
+
+        Mock Stop-TimeLog { '0s' }
+    }
+
+    It 'does not mark successful-only guests as never signed in' {
+        $guests = @(Get-MyGuest)
+
+        $guests.Count | Should -Be 1
+        $guests[0].SignInPattern | Should -Be 'Successful sign-in only'
+        $guests[0].NeverSignedIn | Should -BeFalse
+        $guests[0].NeverSuccessfullySignedIn | Should -BeFalse
+    }
+}

--- a/Tests/MyDeviceLifecycleActions.Tests.ps1
+++ b/Tests/MyDeviceLifecycleActions.Tests.ps1
@@ -1,0 +1,74 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Resolve-MyDeviceActionTarget.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsErrorDetails.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Disable-MyDevice.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Invoke-MyDeviceRetire.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Remove-MyDevice.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Remove-MyDeviceIntuneRecord.ps1')
+}
+
+Describe 'GraphEssentials device lifecycle actions' {
+    BeforeEach {
+        Mock Update-MgDevice {}
+        Mock Invoke-MgRetireDeviceManagementManagedDevice {}
+        Mock Remove-MgDevice {}
+        Mock Remove-MgDeviceManagementManagedDevice {}
+    }
+
+    It 'disables an Entra device using the resolved object id' {
+        $device = [PSCustomObject] @{
+            Name                = 'iPhone-01'
+            EntraDeviceObjectId = 'entra-1'
+            DeviceId            = 'device-1'
+        }
+
+        $result = Disable-MyDevice -InputObject $device -Confirm:$false
+
+        $result.Success | Should -BeTrue
+        Assert-MockCalled Update-MgDevice -Times 1 -Exactly -ParameterFilter {
+            $DeviceId -eq 'entra-1' -and $BodyParameter.accountEnabled -eq $false
+        }
+    }
+
+    It 'retires an Intune device using the managed device id' {
+        $device = [PSCustomObject] @{
+            Name            = 'Android-01'
+            ManagedDeviceId = 'managed-1'
+        }
+
+        $result = Invoke-MyDeviceRetire -InputObject $device -Confirm:$false
+
+        $result.Success | Should -BeTrue
+        Assert-MockCalled Invoke-MgRetireDeviceManagementManagedDevice -Times 1 -Exactly -ParameterFilter {
+            $ManagedDeviceId -eq 'managed-1'
+        }
+    }
+
+    It 'removes an Entra device using the resolved object id' {
+        $device = [PSCustomObject] @{
+            Name                = 'iPad-01'
+            EntraDeviceObjectId = 'entra-2'
+        }
+
+        $result = Remove-MyDevice -InputObject $device -Confirm:$false
+
+        $result.Success | Should -BeTrue
+        Assert-MockCalled Remove-MgDevice -Times 1 -Exactly -ParameterFilter {
+            $DeviceId -eq 'entra-2'
+        }
+    }
+
+    It 'removes an Intune device record using the managed device id' {
+        $device = [PSCustomObject] @{
+            Name            = 'Android-02'
+            ManagedDeviceId = 'managed-2'
+        }
+
+        $result = Remove-MyDeviceIntuneRecord -InputObject $device -Confirm:$false
+
+        $result.Success | Should -BeTrue
+        Assert-MockCalled Remove-MgDeviceManagementManagedDevice -Times 1 -Exactly -ParameterFilter {
+            $ManagedDeviceId -eq 'managed-2'
+        }
+    }
+}

--- a/Tests/MyDeviceLifecycleActions.Tests.ps1
+++ b/Tests/MyDeviceLifecycleActions.Tests.ps1
@@ -5,14 +5,69 @@ BeforeAll {
     . (Join-Path $PSScriptRoot '..\Public\Invoke-MyDeviceRetire.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Remove-MyDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Remove-MyDeviceIntuneRecord.ps1')
+
+    function Update-MgDevice {}
+    function Invoke-MgRetireDeviceManagementManagedDevice {}
+    function Remove-MgDevice {}
+    function Remove-MgDeviceManagementManagedDevice {}
 }
 
 Describe 'GraphEssentials device lifecycle actions' {
     BeforeEach {
-        Mock Update-MgDevice {}
-        Mock Invoke-MgRetireDeviceManagementManagedDevice {}
-        Mock Remove-MgDevice {}
-        Mock Remove-MgDeviceManagementManagedDevice {}
+        $script:UpdateMgDeviceCall = $null
+        $script:RetireManagedDeviceCall = $null
+        $script:RemoveMgDeviceCall = $null
+        $script:RemoveManagedDeviceCall = $null
+
+        function Update-MgDevice {
+            param(
+                $DeviceId,
+                $BodyParameter,
+                $ErrorAction
+            )
+
+            $script:UpdateMgDeviceCall = [PSCustomObject] @{
+                DeviceId      = $DeviceId
+                BodyParameter = $BodyParameter
+                ErrorAction   = $ErrorAction
+            }
+        }
+
+        function Invoke-MgRetireDeviceManagementManagedDevice {
+            param(
+                $ManagedDeviceId,
+                $ErrorAction
+            )
+
+            $script:RetireManagedDeviceCall = [PSCustomObject] @{
+                ManagedDeviceId = $ManagedDeviceId
+                ErrorAction     = $ErrorAction
+            }
+        }
+
+        function Remove-MgDevice {
+            param(
+                $DeviceId,
+                $ErrorAction
+            )
+
+            $script:RemoveMgDeviceCall = [PSCustomObject] @{
+                DeviceId    = $DeviceId
+                ErrorAction = $ErrorAction
+            }
+        }
+
+        function Remove-MgDeviceManagementManagedDevice {
+            param(
+                $ManagedDeviceId,
+                $ErrorAction
+            )
+
+            $script:RemoveManagedDeviceCall = [PSCustomObject] @{
+                ManagedDeviceId = $ManagedDeviceId
+                ErrorAction     = $ErrorAction
+            }
+        }
     }
 
     It 'disables an Entra device using the resolved object id' {
@@ -25,9 +80,8 @@ Describe 'GraphEssentials device lifecycle actions' {
         $result = Disable-MyDevice -InputObject $device -Confirm:$false
 
         $result.Success | Should -BeTrue
-        Assert-MockCalled Update-MgDevice -Times 1 -Exactly -ParameterFilter {
-            $DeviceId -eq 'entra-1' -and $BodyParameter.accountEnabled -eq $false
-        }
+        $script:UpdateMgDeviceCall.DeviceId | Should -Be 'entra-1'
+        $script:UpdateMgDeviceCall.BodyParameter.accountEnabled | Should -BeFalse
     }
 
     It 'retires an Intune device using the managed device id' {
@@ -39,9 +93,7 @@ Describe 'GraphEssentials device lifecycle actions' {
         $result = Invoke-MyDeviceRetire -InputObject $device -Confirm:$false
 
         $result.Success | Should -BeTrue
-        Assert-MockCalled Invoke-MgRetireDeviceManagementManagedDevice -Times 1 -Exactly -ParameterFilter {
-            $ManagedDeviceId -eq 'managed-1'
-        }
+        $script:RetireManagedDeviceCall.ManagedDeviceId | Should -Be 'managed-1'
     }
 
     It 'removes an Entra device using the resolved object id' {
@@ -53,9 +105,7 @@ Describe 'GraphEssentials device lifecycle actions' {
         $result = Remove-MyDevice -InputObject $device -Confirm:$false
 
         $result.Success | Should -BeTrue
-        Assert-MockCalled Remove-MgDevice -Times 1 -Exactly -ParameterFilter {
-            $DeviceId -eq 'entra-2'
-        }
+        $script:RemoveMgDeviceCall.DeviceId | Should -Be 'entra-2'
     }
 
     It 'removes an Intune device record using the managed device id' {
@@ -67,8 +117,6 @@ Describe 'GraphEssentials device lifecycle actions' {
         $result = Remove-MyDeviceIntuneRecord -InputObject $device -Confirm:$false
 
         $result.Success | Should -BeTrue
-        Assert-MockCalled Remove-MgDeviceManagementManagedDevice -Times 1 -Exactly -ParameterFilter {
-            $ManagedDeviceId -eq 'managed-2'
-        }
+        $script:RemoveManagedDeviceCall.ManagedDeviceId | Should -Be 'managed-2'
     }
 }


### PR DESCRIPTION
## Summary

- add dedicated GraphEssentials cmdlets for Intune retire and Entra device disable/remove actions
- enrich device inventory output with stable `EntraDeviceObjectId` and `ManagedDeviceId` properties
- add focused Pester coverage for the new lifecycle helpers

## Why

CleanupMonster now has a cloud-device cleanup workflow for AzureAD registered mobile devices. This PR provides the small Graph-facing action layer that workflow depends on, keeping device lifecycle operations reusable and isolated inside GraphEssentials.

## Impact

Consumers can now script or reuse these device lifecycle actions directly:

- `Disable-MyDevice`
- `Invoke-MyDeviceRetire`
- `Remove-MyDevice`
- `Remove-MyDeviceIntuneRecord`

## Validation

- `Invoke-Pester -Path Tests\\MyDeviceLifecycleActions.Tests.ps1 -Output Minimal`