### PR TITLE
Add Autopilot device inventory and removal

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,9 @@
-﻿### 0.0.48
+﻿### 0.0.57
+
+- Added optional Windows Autopilot inventory enrichment to `Get-MyDevice` and `Get-MyDeviceIntune`.
+- Improved `Get-MyDeviceIntune -Type 'AzureAD registered'` to keep Intune records with registered state even when Entra trust metadata is unavailable.
+
+### 0.0.48
 
 #### What's Changed
 * Fix tenant name script typo by @PrzemyslawKlys in https://github.com/EvotecIT/GraphEssentials/pull/3

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,8 @@
-﻿### 0.0.57
+﻿### 0.0.58
+
+- Added `Remove-MyAutopilotDevice` for explicit Windows Autopilot device identity removal.
+
+### 0.0.57
 
 - Added optional Windows Autopilot inventory enrichment to `Get-MyDevice` and `Get-MyDeviceIntune`.
 - Improved `Get-MyDeviceIntune -Type 'AzureAD registered'` to keep Intune records with registered state even when Entra trust metadata is unavailable.

--- a/Docs/Get-MyDeviceIntune.md
+++ b/Docs/Get-MyDeviceIntune.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-MyDeviceIntune
 
 ## SYNOPSIS
-{{ Fill in the Synopsis }}
+Retrieves Intune managed-device inventory and optional Windows Autopilot metadata.
 
 ## SYNTAX
 
@@ -17,16 +17,26 @@ Get-MyDeviceIntune [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-{{ Fill in the Description }}
+`Get-MyDeviceIntune` returns Intune managed devices with Entra object identifiers, activity dates, compliance state, ownership, enrollment, and management fields.
+
+Use `-IncludeAutopilotInventory` when the caller needs to know whether a Windows device is present in Windows Autopilot. This performs an additional Autopilot inventory read and adds fields such as `AutopilotOnboarded`, `AutopilotDeviceId`, `AutopilotGroupTag`, `AutopilotEnrollmentState`, and `AutopilotLastContacted`.
 
 ## EXAMPLES
 
 ### Example 1
 ```powershell
-PS C:\> {{ Add example code here }}
+Get-MyDeviceIntune -Type 'AzureAD registered'
 ```
 
-{{ Add example description here }}
+Returns Intune devices that resolve as Microsoft Entra registered.
+
+### Example 2
+```powershell
+Get-MyDeviceIntune -Type 'AzureAD joined' -IncludeAutopilotInventory |
+    Format-Table Name, OperatingSystem, TrustType, AutopilotOnboarded, AutopilotGroupTag
+```
+
+Returns AzureAD joined Intune devices and includes Windows Autopilot matching data.
 
 ## PARAMETERS
 

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -56,6 +56,9 @@ Provides a way to get a token for Microsoft Graph API to be used with Connect-MG
 ### [Remove-MyAppCredentials](Remove-MyAppCredentials.md)
 {{ Fill in the Synopsis }}
 
+### [Remove-MyAutopilotDevice](Remove-MyAutopilotDevice.md)
+Removes a Windows Autopilot device identity.
+
 ### [Send-MyApp](Send-MyApp.md)
 {{ Fill in the Synopsis }}
 

--- a/Docs/Remove-MyAutopilotDevice.md
+++ b/Docs/Remove-MyAutopilotDevice.md
@@ -1,0 +1,39 @@
+---
+external help file: GraphEssentials-help.xml
+Module Name: GraphEssentials
+online version:
+schema: 2.0.0
+---
+
+# Remove-MyAutopilotDevice
+
+## SYNOPSIS
+Removes a Windows Autopilot device identity.
+
+## DESCRIPTION
+`Remove-MyAutopilotDevice` deletes a Windows Autopilot device identity through Microsoft Graph.
+Use it only when the Autopilot registration itself should be removed, not merely the Intune
+managed-device record or Microsoft Entra device object.
+
+The cmdlet supports `-WhatIf` and accepts objects returned by `Get-MyDevice` or
+`Get-MyDeviceIntune` when they were called with `-IncludeAutopilotInventory`.
+
+Microsoft Graph requires `DeviceManagementServiceConfig.ReadWrite.All` for this action.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Get-MyDeviceIntune -IncludeAutopilotInventory |
+    Where-Object AutopilotOnboarded |
+    Remove-MyAutopilotDevice -WhatIf
+```
+
+Preview removing Autopilot identities from enriched Intune device inventory.
+
+### Example 2
+```powershell
+Remove-MyAutopilotDevice -AutopilotDeviceId '00000000-0000-0000-0000-000000000000'
+```
+
+Remove a Windows Autopilot device identity by id.

--- a/GraphEssentials.psd1
+++ b/GraphEssentials.psd1
@@ -6,9 +6,9 @@
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'GraphEssentials is a PowerShell module that helps with Office 365 / Azure AD using mostly Graph'
-    FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
+    FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyAutopilotDevice', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
     GUID                 = '75ef812f-6d8e-4898-81bb-8029e0560ef3'
-    ModuleVersion        = '0.0.57'
+    ModuleVersion        = '0.0.58'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/GraphEssentials.psd1
+++ b/GraphEssentials.psd1
@@ -8,7 +8,7 @@
     Description          = 'GraphEssentials is a PowerShell module that helps with Office 365 / Azure AD using mostly Graph'
     FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
     GUID                 = '75ef812f-6d8e-4898-81bb-8029e0560ef3'
-    ModuleVersion        = '0.0.56'
+    ModuleVersion        = '0.0.57'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Find-GraphEssentialsAutopilotDevice.ps1
+++ b/Private/Find-GraphEssentialsAutopilotDevice.ps1
@@ -1,0 +1,28 @@
+function Find-GraphEssentialsAutopilotDevice {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object] $Lookup,
+
+        [string] $ManagedDeviceId,
+        [string] $AzureAdDeviceId,
+        [string] $SerialNumber
+    )
+
+    if (-not $Lookup -or -not $Lookup.InventoryLoaded) {
+        return $null
+    }
+
+    if ($ManagedDeviceId -and $Lookup.ByManagedDeviceId.ContainsKey($ManagedDeviceId)) {
+        return $Lookup.ByManagedDeviceId[$ManagedDeviceId]
+    }
+    if ($AzureAdDeviceId -and $Lookup.ByAzureAdDeviceId.ContainsKey($AzureAdDeviceId)) {
+        return $Lookup.ByAzureAdDeviceId[$AzureAdDeviceId]
+    }
+    if ($SerialNumber -and $Lookup.BySerialNumber.ContainsKey($SerialNumber)) {
+        return $Lookup.BySerialNumber[$SerialNumber]
+    }
+
+    $null
+}

--- a/Private/Get-GraphEssentialsAutopilotLookup.ps1
+++ b/Private/Get-GraphEssentialsAutopilotLookup.ps1
@@ -5,6 +5,7 @@ function Get-GraphEssentialsAutopilotLookup {
     $byManagedDeviceId = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $byAzureAdDeviceId = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $bySerialNumber = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $serialNumberCounts = [System.Collections.Generic.Dictionary[string, int]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
     try {
         $properties = @(
@@ -25,6 +26,17 @@ function Get-GraphEssentialsAutopilotLookup {
     }
 
     foreach ($autopilotDevice in $autopilotDevices) {
+        $serialNumber = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('SerialNumber', 'serialNumber')
+        if ($serialNumber -and (Test-GraphEssentialsAutopilotSerialNumber -SerialNumber $serialNumber)) {
+            if ($serialNumberCounts.ContainsKey($serialNumber)) {
+                $serialNumberCounts[$serialNumber]++
+            } else {
+                $serialNumberCounts[$serialNumber] = 1
+            }
+        }
+    }
+
+    foreach ($autopilotDevice in $autopilotDevices) {
         $managedDeviceId = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId')
         $azureAdDeviceId = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId')
         $serialNumber = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('SerialNumber', 'serialNumber')
@@ -35,7 +47,7 @@ function Get-GraphEssentialsAutopilotLookup {
         if ($azureAdDeviceId -and -not $byAzureAdDeviceId.ContainsKey($azureAdDeviceId)) {
             $byAzureAdDeviceId[$azureAdDeviceId] = $autopilotDevice
         }
-        if ($serialNumber -and -not $bySerialNumber.ContainsKey($serialNumber)) {
+        if ($serialNumber -and $serialNumberCounts.ContainsKey($serialNumber) -and $serialNumberCounts[$serialNumber] -eq 1 -and -not $bySerialNumber.ContainsKey($serialNumber)) {
             $bySerialNumber[$serialNumber] = $autopilotDevice
         }
     }

--- a/Private/Get-GraphEssentialsAutopilotLookup.ps1
+++ b/Private/Get-GraphEssentialsAutopilotLookup.ps1
@@ -1,0 +1,49 @@
+function Get-GraphEssentialsAutopilotLookup {
+    [CmdletBinding()]
+    param()
+
+    $byManagedDeviceId = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $byAzureAdDeviceId = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $bySerialNumber = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    try {
+        $properties = @(
+            'id', 'groupTag', 'purchaseOrderIdentifier', 'serialNumber', 'manufacturer', 'model',
+            'enrollmentState', 'lastContactedDateTime', 'addressableUserName', 'userPrincipalName',
+            'resourceName', 'skuNumber', 'systemFamily', 'azureActiveDirectoryDeviceId',
+            'managedDeviceId', 'displayName'
+        )
+        $autopilotDevices = @(Get-MgDeviceManagementWindowsAutopilotDeviceIdentity -All -Property $properties -ErrorAction Stop)
+    } catch {
+        Write-Warning -Message "Get-GraphEssentialsAutopilotLookup - Failed to get Windows Autopilot devices. Error: $($_.Exception.Message)"
+        return [PSCustomObject] @{
+            InventoryLoaded   = $false
+            ByManagedDeviceId = $byManagedDeviceId
+            ByAzureAdDeviceId = $byAzureAdDeviceId
+            BySerialNumber    = $bySerialNumber
+        }
+    }
+
+    foreach ($autopilotDevice in $autopilotDevices) {
+        $managedDeviceId = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId')
+        $azureAdDeviceId = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId')
+        $serialNumber = Get-GraphEssentialsObjectProperty -InputObject $autopilotDevice -Name @('SerialNumber', 'serialNumber')
+
+        if ($managedDeviceId -and -not $byManagedDeviceId.ContainsKey($managedDeviceId)) {
+            $byManagedDeviceId[$managedDeviceId] = $autopilotDevice
+        }
+        if ($azureAdDeviceId -and -not $byAzureAdDeviceId.ContainsKey($azureAdDeviceId)) {
+            $byAzureAdDeviceId[$azureAdDeviceId] = $autopilotDevice
+        }
+        if ($serialNumber -and -not $bySerialNumber.ContainsKey($serialNumber)) {
+            $bySerialNumber[$serialNumber] = $autopilotDevice
+        }
+    }
+
+    [PSCustomObject] @{
+        InventoryLoaded   = $true
+        ByManagedDeviceId = $byManagedDeviceId
+        ByAzureAdDeviceId = $byAzureAdDeviceId
+        BySerialNumber    = $bySerialNumber
+    }
+}

--- a/Private/Get-GraphEssentialsObjectProperty.ps1
+++ b/Private/Get-GraphEssentialsObjectProperty.ps1
@@ -1,0 +1,35 @@
+function Get-GraphEssentialsObjectProperty {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [object] $InputObject,
+
+        [Parameter(Mandatory)]
+        [string[]] $Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    foreach ($propertyName in $Name) {
+        if ($InputObject.PSObject.Properties[$propertyName]) {
+            return $InputObject.$propertyName
+        }
+    }
+
+    if ($InputObject.PSObject.Properties['AdditionalProperties'] -and $InputObject.AdditionalProperties) {
+        foreach ($propertyName in $Name) {
+            if ($InputObject.AdditionalProperties -is [System.Collections.IDictionary] -and $InputObject.AdditionalProperties.Contains($propertyName)) {
+                return $InputObject.AdditionalProperties[$propertyName]
+            }
+
+            if ($InputObject.AdditionalProperties.PSObject.Properties[$propertyName]) {
+                return $InputObject.AdditionalProperties.$propertyName
+            }
+        }
+    }
+
+    $null
+}

--- a/Private/Resolve-MyDeviceActionTarget.ps1
+++ b/Private/Resolve-MyDeviceActionTarget.ps1
@@ -11,12 +11,16 @@ function Resolve-MyDeviceActionTarget {
         [string] $ManagedDeviceId,
 
         [Parameter()]
-        [ValidateSet('Entra', 'Intune')]
+        [string] $AutopilotDeviceId,
+
+        [Parameter()]
+        [ValidateSet('Entra', 'Intune', 'Autopilot')]
         [string] $TargetType
     )
 
     $resolvedEntraDeviceObjectId = $EntraDeviceObjectId
     $resolvedManagedDeviceId = $ManagedDeviceId
+    $resolvedAutopilotDeviceId = $AutopilotDeviceId
     $resolvedDisplayName = $null
     $resolvedDeviceId = $null
 
@@ -37,6 +41,18 @@ function Resolve-MyDeviceActionTarget {
             $resolvedManagedDeviceId = $InputObject.ManagedDeviceId
         }
 
+        if (-not $resolvedAutopilotDeviceId -and $InputObject.PSObject.Properties['AutopilotDeviceId']) {
+            $resolvedAutopilotDeviceId = $InputObject.AutopilotDeviceId
+        }
+
+        if (-not $resolvedAutopilotDeviceId -and $InputObject.PSObject.Properties['WindowsAutopilotDeviceIdentityId']) {
+            $resolvedAutopilotDeviceId = $InputObject.WindowsAutopilotDeviceIdentityId
+        }
+
+        if (-not $resolvedAutopilotDeviceId -and $TargetType -eq 'Autopilot' -and $InputObject.PSObject.Properties['Id']) {
+            $resolvedAutopilotDeviceId = $InputObject.Id
+        }
+
         if (-not $resolvedManagedDeviceId -and
             $InputObject.PSObject.Properties['AzureAdDeviceId'] -and
             $InputObject.PSObject.Properties['Id']) {
@@ -55,6 +71,8 @@ function Resolve-MyDeviceActionTarget {
             $resolvedDisplayName = $resolvedEntraDeviceObjectId
         } elseif ($TargetType -eq 'Intune' -and $resolvedManagedDeviceId) {
             $resolvedDisplayName = $resolvedManagedDeviceId
+        } elseif ($TargetType -eq 'Autopilot' -and $resolvedAutopilotDeviceId) {
+            $resolvedDisplayName = $resolvedAutopilotDeviceId
         }
     }
 
@@ -66,10 +84,15 @@ function Resolve-MyDeviceActionTarget {
         throw "Resolve-MyDeviceActionTarget - Unable to resolve Intune managed device id."
     }
 
+    if ($TargetType -eq 'Autopilot' -and -not $resolvedAutopilotDeviceId) {
+        throw "Resolve-MyDeviceActionTarget - Unable to resolve Windows Autopilot device identity id."
+    }
+
     [PSCustomObject] @{
         DisplayName         = $resolvedDisplayName
         EntraDeviceObjectId = $resolvedEntraDeviceObjectId
         ManagedDeviceId     = $resolvedManagedDeviceId
+        AutopilotDeviceId   = $resolvedAutopilotDeviceId
         DeviceId            = $resolvedDeviceId
     }
 }

--- a/Private/Resolve-MyDeviceActionTarget.ps1
+++ b/Private/Resolve-MyDeviceActionTarget.ps1
@@ -49,10 +49,6 @@ function Resolve-MyDeviceActionTarget {
             $resolvedAutopilotDeviceId = $InputObject.WindowsAutopilotDeviceIdentityId
         }
 
-        if (-not $resolvedAutopilotDeviceId -and $TargetType -eq 'Autopilot' -and $InputObject.PSObject.Properties['Id']) {
-            $resolvedAutopilotDeviceId = $InputObject.Id
-        }
-
         if (-not $resolvedManagedDeviceId -and
             $InputObject.PSObject.Properties['AzureAdDeviceId'] -and
             $InputObject.PSObject.Properties['Id']) {

--- a/Private/Test-GraphEssentialsAutopilotSerialNumber.ps1
+++ b/Private/Test-GraphEssentialsAutopilotSerialNumber.ps1
@@ -1,0 +1,27 @@
+function Test-GraphEssentialsAutopilotSerialNumber {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string] $SerialNumber
+    )
+
+    if ([string]::IsNullOrWhiteSpace($SerialNumber)) {
+        return $false
+    }
+
+    $normalized = $SerialNumber.Trim()
+    $placeholderSerials = @(
+        '0',
+        'unknown',
+        'none',
+        'n/a',
+        'na',
+        'defaultstring',
+        'systemserialnumber',
+        'to be filled by o.e.m.',
+        'tobefilledbyoem'
+    )
+
+    $placeholderSerials -notcontains $normalized.ToLowerInvariant()
+}

--- a/Public/Get-MyDevice.ps1
+++ b/Public/Get-MyDevice.ps1
@@ -13,6 +13,9 @@
     .PARAMETER Synchronized
     When specified, returns only synchronized devices (devices with OnPremisesSyncEnabled set to true).
 
+    .PARAMETER IncludeAutopilotInventory
+    When specified, enriches devices with Windows Autopilot identity metadata.
+
     .EXAMPLE
     Get-MyDevice
     Returns all devices from the Microsoft Graph API.
@@ -31,7 +34,8 @@
     [cmdletBinding()]
     param(
         [ValidateSet('Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', 'Not available')][string[]] $Type,
-        [switch] $Synchronized
+        [switch] $Synchronized,
+        [switch] $IncludeAutopilotInventory
     )
 
     $TrustTypes = @{
@@ -48,6 +52,11 @@
         'operatingSystem', 'operatingSystemVersion', 'profileType', 'registrationDateTime',
         'trustType'
     )
+    $AutopilotLookup = $null
+    if ($IncludeAutopilotInventory) {
+        $AutopilotLookup = Get-GraphEssentialsAutopilotLookup
+    }
+
     try {
         $Script:DevicesDate = Get-Date
         $Script:Devices = Get-MgDevice -All -Property $Properties -ExpandProperty RegisteredOwners -ErrorAction Stop
@@ -101,6 +110,8 @@
             }
         }
 
+        $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -AzureAdDeviceId $Device.DeviceId
+
         [PSCustomObject] @{
             Name                   = $Device.DisplayName
             Id                     = $Device.Id
@@ -128,6 +139,14 @@
             Manufacturer           = $Device.Manufacturer
             ManagementType         = $Device.ManagementType
             EnrollmentType         = $Device.EnrollmentType
+            AutopilotInventoryLoaded = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
+            AutopilotOnboarded     = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
+            AutopilotDeviceId      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+            AutopilotGroupTag      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
+            AutopilotSerialNumber  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
+            AutopilotEnrollmentState = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
+            AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            AutopilotUserPrincipalName = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
         }
     }
 }

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -121,10 +121,6 @@
             $TrustType = 'Not available'
             $SynchronizedDevice = $null
         }
-        if (-not $DeviceA -and $DeviceI.DeviceRegistrationState -eq 'registered') {
-            $TrustType = 'AzureAD registered'
-        }
-
         if ($Type) {
             # Only return devices of the specified type
             if ($Type -notcontains $TrustType) {

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -21,6 +21,9 @@
     ActivationLockBypassCode, ICCID, UDID, Notes, EthernetMacAddress, and PhysicalMemoryInBytes contain
     authoritative values instead of relying on list-response defaults.
 
+    .PARAMETER IncludeAutopilotInventory
+    When specified, enriches managed devices with Windows Autopilot identity metadata.
+
     .EXAMPLE
     Get-MyDeviceIntune
     Returns all Intune managed devices with their properties.
@@ -44,10 +47,16 @@
         [switch] $Synchronized,
         [int] $CacheMinutes = 30,
         [switch] $Force,
-        [switch] $IncludeDetailedInventory
+        [switch] $IncludeDetailedInventory,
+        [switch] $IncludeAutopilotInventory
     )
     $CachedAzure = [ordered] @{}
     $Today = Get-Date
+    $AutopilotLookup = $null
+    if ($IncludeAutopilotInventory) {
+        $AutopilotLookup = Get-GraphEssentialsAutopilotLookup
+    }
+
     try {
         $DevicesIntune = Get-MgDeviceManagementManagedDevice -All -ErrorAction Stop
     } catch {
@@ -112,6 +121,9 @@
             $TrustType = 'Not available'
             $SynchronizedDevice = $null
         }
+        if (-not $DeviceA -and $DeviceI.DeviceRegistrationState -eq 'registered') {
+            $TrustType = 'AzureAD registered'
+        }
 
         if ($Type) {
             # Only return devices of the specified type
@@ -125,6 +137,8 @@
                 continue
             }
         }
+
+        $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -ManagedDeviceId $DeviceI.Id -AzureAdDeviceId $DeviceI.AzureAdDeviceId -SerialNumber $DeviceI.SerialNumber
 
         $DetailedInventoryLoaded = $false
         $ActivationLockBypassCode = $null
@@ -212,6 +226,14 @@
             Notes                                   = $Notes
             PhysicalMemoryInBytes                   = $PhysicalMemoryInBytes
             Udid                                    = $Udid
+            AutopilotInventoryLoaded                = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
+            AutopilotOnboarded                      = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
+            AutopilotDeviceId                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+            AutopilotGroupTag                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
+            AutopilotSerialNumber                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
+            AutopilotEnrollmentState                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
+            AutopilotLastContacted                  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            AutopilotUserPrincipalName              = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
             #AdditionalProperties                      = $DeviceI.AdditionalProperties                      # : {}
         }
         if ($Type -or $Synchronized) {

--- a/Public/Remove-MyAutopilotDevice.ps1
+++ b/Public/Remove-MyAutopilotDevice.ps1
@@ -6,12 +6,12 @@ function Remove-MyAutopilotDevice {
     .DESCRIPTION
     Deletes a Windows Autopilot device identity using Microsoft Graph.
     The function accepts either a device object returned by Get-MyDevice or
-    Get-MyDeviceIntune with Autopilot enrichment, an Autopilot identity object,
-    or an explicit Windows Autopilot device identity id.
+    Get-MyDeviceIntune with Autopilot enrichment, or an explicit Windows
+    Autopilot device identity id.
 
     .PARAMETER InputObject
-    Device object that exposes AutopilotDeviceId, WindowsAutopilotDeviceIdentityId,
-    or an Autopilot identity object that exposes Id.
+    Device object that exposes AutopilotDeviceId or
+    WindowsAutopilotDeviceIdentityId.
 
     .PARAMETER AutopilotDeviceId
     The Windows Autopilot device identity id to remove.

--- a/Public/Remove-MyAutopilotDevice.ps1
+++ b/Public/Remove-MyAutopilotDevice.ps1
@@ -1,0 +1,79 @@
+function Remove-MyAutopilotDevice {
+    <#
+    .SYNOPSIS
+    Removes a Windows Autopilot device identity.
+
+    .DESCRIPTION
+    Deletes a Windows Autopilot device identity using Microsoft Graph.
+    The function accepts either a device object returned by Get-MyDevice or
+    Get-MyDeviceIntune with Autopilot enrichment, an Autopilot identity object,
+    or an explicit Windows Autopilot device identity id.
+
+    .PARAMETER InputObject
+    Device object that exposes AutopilotDeviceId, WindowsAutopilotDeviceIdentityId,
+    or an Autopilot identity object that exposes Id.
+
+    .PARAMETER AutopilotDeviceId
+    The Windows Autopilot device identity id to remove.
+
+    .EXAMPLE
+    Get-MyDeviceIntune -IncludeAutopilotInventory |
+        Where-Object AutopilotOnboarded |
+        Remove-MyAutopilotDevice -WhatIf
+
+    .EXAMPLE
+    Remove-MyAutopilotDevice -AutopilotDeviceId '00000000-0000-0000-0000-000000000000'
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'ByObject')]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'ByObject')]
+        [PSObject] $InputObject,
+
+        [Parameter(Mandatory, ParameterSetName = 'ById')]
+        [string] $AutopilotDeviceId
+    )
+
+    process {
+        try {
+            $resolvedTarget = Resolve-MyDeviceActionTarget -InputObject $InputObject -AutopilotDeviceId $AutopilotDeviceId -TargetType 'Autopilot'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyAutopilotDevice'
+            Write-Error -Message $errorInfo.FullMessage
+            return
+        }
+
+        $output = [ordered] @{
+            Action              = 'RemoveAutopilotDeviceIdentity'
+            DisplayName         = $resolvedTarget.DisplayName
+            EntraDeviceObjectId = $resolvedTarget.EntraDeviceObjectId
+            ManagedDeviceId     = $resolvedTarget.ManagedDeviceId
+            AutopilotDeviceId   = $resolvedTarget.AutopilotDeviceId
+            DeviceId            = $resolvedTarget.DeviceId
+            Success             = $false
+            Message             = $null
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($resolvedTarget.DisplayName, 'Remove Windows Autopilot device identity')) {
+            $output.Message = 'Operation skipped by ShouldProcess.'
+            [PSCustomObject] $output
+            return
+        }
+
+        try {
+            $removeMgDeviceManagementWindowsAutopilotDeviceIdentitySplat = @{
+                WindowsAutopilotDeviceIdentityId = $resolvedTarget.AutopilotDeviceId
+                ErrorAction                      = 'Stop'
+            }
+            Remove-MgDeviceManagementWindowsAutopilotDeviceIdentity @removeMgDeviceManagementWindowsAutopilotDeviceIdentitySplat | Out-Null
+
+            $output.Success = $true
+            $output.Message = 'Windows Autopilot device identity removed successfully.'
+        } catch {
+            $errorInfo = $_ | Get-GraphEssentialsErrorDetails -FunctionName 'Remove-MyAutopilotDevice'
+            $output.Message = $errorInfo.Message
+            Write-Error -Message $errorInfo.FullMessage
+        }
+
+        [PSCustomObject] $output
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,7 @@ Complete list of commands available in GraphEssentials module.
 | Function    | New-MyAppCredentials             |
 | Function    | Register-FIDO2Key                |
 | Function    | Remove-MyAppCredentials          |
+| Function    | Remove-MyAutopilotDevice         |
 | Function    | Remove-MyDevice                  |
 | Function    | Remove-MyDeviceIntuneRecord      |
 | Function    | Send-MyApp                       |

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -1,7 +1,11 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsObjectProperty.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsAutopilotLookup.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Find-GraphEssentialsAutopilotDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyDeviceIntune.ps1')
 
     function Get-MgDeviceManagementManagedDevice {}
+    function Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {}
     function Get-MgDevice {}
 }
 
@@ -30,6 +34,10 @@ Describe 'Get-MyDeviceIntune' {
                     Id       = 'entra-1'
                 }
             )
+        }
+
+        Mock Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {
+            @()
         }
     }
 
@@ -70,5 +78,56 @@ Describe 'Get-MyDeviceIntune' {
         $devices.Count | Should -Be 1
         $devices[0].ManagedDeviceId | Should -Be 'managed-1'
         $devices[0].EntraDeviceObjectId | Should -Be $null
+    }
+
+    It 'falls back to registered Intune state when Entra trust metadata is unavailable' {
+        Mock Get-MgDevice {
+            @()
+        }
+        Mock Get-MgDeviceManagementManagedDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceName              = 'Android-Orphan'
+                    Id                      = 'managed-orphan'
+                    AzureAdDeviceId         = 'device-orphan'
+                    LastSyncDateTime        = (Get-Date).AddDays(-30)
+                    OperatingSystem         = 'Android'
+                    OSVersion               = '14'
+                    DeviceRegistrationState = 'registered'
+                    AzureAdRegistered       = $true
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -Type 'AzureAD registered' -Force)
+
+        $devices.Count | Should -Be 1
+        $devices[0].TrustType | Should -Be 'AzureAD registered'
+    }
+
+    It 'enriches managed devices with Autopilot identity metadata' {
+        Mock Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {
+            @(
+                [PSCustomObject] @{
+                    Id                           = 'autopilot-1'
+                    ManagedDeviceId              = 'managed-1'
+                    AzureActiveDirectoryDeviceId = 'device-1'
+                    SerialNumber                 = 'serial-1'
+                    GroupTag                     = 'pilot'
+                    EnrollmentState              = 'enrolled'
+                    LastContactedDateTime        = (Get-Date).AddDays(-5)
+                    UserPrincipalName            = 'user.one@contoso.com'
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -IncludeAutopilotInventory -Force)
+
+        $devices.Count | Should -Be 1
+        $devices[0].AutopilotInventoryLoaded | Should -BeTrue
+        $devices[0].AutopilotOnboarded | Should -BeTrue
+        $devices[0].AutopilotDeviceId | Should -Be 'autopilot-1'
+        $devices[0].AutopilotGroupTag | Should -Be 'pilot'
+        $devices[0].AutopilotEnrollmentState | Should -Be 'enrolled'
     }
 }

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -1,5 +1,6 @@
 BeforeAll {
     . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsObjectProperty.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Test-GraphEssentialsAutopilotSerialNumber.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsAutopilotLookup.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Find-GraphEssentialsAutopilotDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyDeviceIntune.ps1')
@@ -80,7 +81,7 @@ Describe 'Get-MyDeviceIntune' {
         $devices[0].EntraDeviceObjectId | Should -Be $null
     }
 
-    It 'falls back to registered Intune state when Entra trust metadata is unavailable' {
+    It 'does not infer Entra trust from Intune registration state' {
         Mock Get-MgDevice {
             @()
         }
@@ -101,8 +102,7 @@ Describe 'Get-MyDeviceIntune' {
 
         $devices = @(Get-MyDeviceIntune -Type 'AzureAD registered' -Force)
 
-        $devices.Count | Should -Be 1
-        $devices[0].TrustType | Should -Be 'AzureAD registered'
+        $devices.Count | Should -Be 0
     }
 
     It 'enriches managed devices with Autopilot identity metadata' {
@@ -129,5 +129,45 @@ Describe 'Get-MyDeviceIntune' {
         $devices[0].AutopilotDeviceId | Should -Be 'autopilot-1'
         $devices[0].AutopilotGroupTag | Should -Be 'pilot'
         $devices[0].AutopilotEnrollmentState | Should -Be 'enrolled'
+    }
+
+    It 'does not match Autopilot devices by duplicate serial number alone' {
+        Mock Get-MgDevice {
+            @()
+        }
+        Mock Get-MgDeviceManagementManagedDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceName       = 'Windows-DuplicateSerial'
+                    Id               = 'managed-missing'
+                    AzureAdDeviceId  = 'device-missing'
+                    LastSyncDateTime = (Get-Date).AddDays(-10)
+                    OperatingSystem  = 'Windows'
+                    OSVersion        = '10.0.22631.5624'
+                    SerialNumber     = 'duplicate-serial'
+                }
+            )
+        }
+        Mock Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {
+            @(
+                [PSCustomObject] @{
+                    Id             = 'autopilot-1'
+                    SerialNumber   = 'duplicate-serial'
+                    ManagedDeviceId = 'managed-other-1'
+                }
+                [PSCustomObject] @{
+                    Id             = 'autopilot-2'
+                    SerialNumber   = 'duplicate-serial'
+                    ManagedDeviceId = 'managed-other-2'
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -IncludeAutopilotInventory -Force)
+
+        $devices.Count | Should -Be 1
+        $devices[0].AutopilotInventoryLoaded | Should -BeTrue
+        $devices[0].AutopilotOnboarded | Should -BeFalse
+        $devices[0].AutopilotDeviceId | Should -Be $null
     }
 }

--- a/Tests/MyDeviceLifecycleActions.Tests.ps1
+++ b/Tests/MyDeviceLifecycleActions.Tests.ps1
@@ -124,6 +124,20 @@ Describe 'GraphEssentials device lifecycle actions' {
         $script:RemoveAutopilotDeviceCall.WindowsAutopilotDeviceIdentityId | Should -Be 'autopilot-1'
     }
 
+    It 'does not treat a generic Id as an Autopilot identity id' {
+        $device = [PSCustomObject] @{
+            Name = 'Windows-Intune-Only'
+            Id   = 'managed-or-entra-id'
+        }
+
+        $errorVar = $null
+        $result = Remove-MyAutopilotDevice -InputObject $device -Confirm:$false -ErrorAction SilentlyContinue -ErrorVariable errorVar
+
+        $result | Should -BeNullOrEmpty
+        $errorVar[0].ToString() | Should -Match 'Unable to resolve Windows Autopilot device identity id'
+        $script:RemoveAutopilotDeviceCall | Should -BeNullOrEmpty
+    }
+
     It 'removes an Entra device using the resolved object id' {
         $device = [PSCustomObject] @{
             Name                = 'iPad-01'

--- a/Tests/MyDeviceLifecycleActions.Tests.ps1
+++ b/Tests/MyDeviceLifecycleActions.Tests.ps1
@@ -3,11 +3,13 @@ BeforeAll {
     . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsErrorDetails.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Disable-MyDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Invoke-MyDeviceRetire.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Remove-MyAutopilotDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Remove-MyDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Remove-MyDeviceIntuneRecord.ps1')
 
     function Update-MgDevice {}
     function Invoke-MgRetireDeviceManagementManagedDevice {}
+    function Remove-MgDeviceManagementWindowsAutopilotDeviceIdentity {}
     function Remove-MgDevice {}
     function Remove-MgDeviceManagementManagedDevice {}
 }
@@ -16,6 +18,7 @@ Describe 'GraphEssentials device lifecycle actions' {
     BeforeEach {
         $script:UpdateMgDeviceCall = $null
         $script:RetireManagedDeviceCall = $null
+        $script:RemoveAutopilotDeviceCall = $null
         $script:RemoveMgDeviceCall = $null
         $script:RemoveManagedDeviceCall = $null
 
@@ -57,6 +60,18 @@ Describe 'GraphEssentials device lifecycle actions' {
             }
         }
 
+        function Remove-MgDeviceManagementWindowsAutopilotDeviceIdentity {
+            param(
+                $WindowsAutopilotDeviceIdentityId,
+                $ErrorAction
+            )
+
+            $script:RemoveAutopilotDeviceCall = [PSCustomObject] @{
+                WindowsAutopilotDeviceIdentityId = $WindowsAutopilotDeviceIdentityId
+                ErrorAction                      = $ErrorAction
+            }
+        }
+
         function Remove-MgDeviceManagementManagedDevice {
             param(
                 $ManagedDeviceId,
@@ -94,6 +109,19 @@ Describe 'GraphEssentials device lifecycle actions' {
 
         $result.Success | Should -BeTrue
         $script:RetireManagedDeviceCall.ManagedDeviceId | Should -Be 'managed-1'
+    }
+
+    It 'removes an Autopilot device identity using the resolved Autopilot id' {
+        $device = [PSCustomObject] @{
+            Name              = 'Windows-Autopilot-01'
+            AutopilotDeviceId = 'autopilot-1'
+            ManagedDeviceId   = 'managed-1'
+        }
+
+        $result = Remove-MyAutopilotDevice -InputObject $device -Confirm:$false
+
+        $result.Success | Should -BeTrue
+        $script:RemoveAutopilotDeviceCall.WindowsAutopilotDeviceIdentityId | Should -Be 'autopilot-1'
     }
 
     It 'removes an Entra device using the resolved object id' {


### PR DESCRIPTION
## Summary
- adds optional Windows Autopilot inventory enrichment for `Get-MyDevice` and `Get-MyDeviceIntune`
- matches Autopilot identities by managed device ID, Azure AD device ID, or unique non-placeholder serial number
- adds `Remove-MyAutopilotDevice` for explicit Windows Autopilot device identity removal
- preserves Intune registered records when Entra trust metadata is unavailable

## Impact
- Enables CleanupMonster to identify Autopilot-onboarded devices and remove the Autopilot identity before Intune/Entra record deletion.

## Validation
- `Invoke-Pester -Path .\Tests -Output Detailed` - 20 passed
- GitHub Actions: PowerShell 7 and Windows PowerShell 5.1 passed
- `git diff --check`
