### PR TITLE
Expose Autopilot association metadata

### DIFF
--- a/GraphEssentials.psd1
+++ b/GraphEssentials.psd1
@@ -8,7 +8,7 @@
     Description          = 'GraphEssentials is a PowerShell module that helps with Office 365 / Azure AD using mostly Graph'
     FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyAutopilotDevice', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
     GUID                 = '75ef812f-6d8e-4898-81bb-8029e0560ef3'
-    ModuleVersion        = '0.0.58'
+    ModuleVersion        = '0.0.59'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Public/Get-MyDevice.ps1
+++ b/Public/Get-MyDevice.ps1
@@ -111,6 +111,8 @@
         }
 
         $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -AzureAdDeviceId $Device.DeviceId
+        $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+        $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
 
         [PSCustomObject] @{
             Name                   = $Device.DisplayName
@@ -142,10 +144,14 @@
             AutopilotInventoryLoaded = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
             AutopilotOnboarded     = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
             AutopilotDeviceId      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+            AutopilotManagedDeviceId = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
+            AutopilotAzureAdDeviceId = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
+            AutopilotResourceName  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
             AutopilotGroupTag      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
             AutopilotSerialNumber  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
             AutopilotEnrollmentState = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
-            AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            AutopilotLastContacted = $AutopilotLastContacted
+            AutopilotLastContactedDays = $AutopilotLastContactedDays
             AutopilotUserPrincipalName = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
         }
     }

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -135,6 +135,8 @@
         }
 
         $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -ManagedDeviceId $DeviceI.Id -AzureAdDeviceId $DeviceI.AzureAdDeviceId -SerialNumber $DeviceI.SerialNumber
+        $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+        $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
 
         $DetailedInventoryLoaded = $false
         $ActivationLockBypassCode = $null
@@ -225,10 +227,14 @@
             AutopilotInventoryLoaded                = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
             AutopilotOnboarded                      = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
             AutopilotDeviceId                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+            AutopilotManagedDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
+            AutopilotAzureAdDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
+            AutopilotResourceName                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
             AutopilotGroupTag                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
             AutopilotSerialNumber                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
             AutopilotEnrollmentState                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
-            AutopilotLastContacted                  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            AutopilotLastContacted                  = $AutopilotLastContacted
+            AutopilotLastContactedDays              = $AutopilotLastContactedDays
             AutopilotUserPrincipalName              = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
             #AdditionalProperties                      = $DeviceI.AdditionalProperties                      # : {}
         }

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -113,6 +113,7 @@ Describe 'Get-MyDeviceIntune' {
                     ManagedDeviceId              = 'managed-1'
                     AzureActiveDirectoryDeviceId = 'device-1'
                     SerialNumber                 = 'serial-1'
+                    ResourceName                 = 'serial-1'
                     GroupTag                     = 'pilot'
                     EnrollmentState              = 'enrolled'
                     LastContactedDateTime        = (Get-Date).AddDays(-5)
@@ -127,8 +128,13 @@ Describe 'Get-MyDeviceIntune' {
         $devices[0].AutopilotInventoryLoaded | Should -BeTrue
         $devices[0].AutopilotOnboarded | Should -BeTrue
         $devices[0].AutopilotDeviceId | Should -Be 'autopilot-1'
+        $devices[0].AutopilotManagedDeviceId | Should -Be 'managed-1'
+        $devices[0].AutopilotAzureAdDeviceId | Should -Be 'device-1'
+        $devices[0].AutopilotResourceName | Should -Be 'serial-1'
         $devices[0].AutopilotGroupTag | Should -Be 'pilot'
+        $devices[0].AutopilotSerialNumber | Should -Be 'serial-1'
         $devices[0].AutopilotEnrollmentState | Should -Be 'enrolled'
+        $devices[0].AutopilotLastContactedDays | Should -BeGreaterOrEqual 4
     }
 
     It 'does not match Autopilot devices by duplicate serial number alone' {


### PR DESCRIPTION
## Summary
- expose Autopilot managed-device, Entra-device, resource-name, and last-contact age fields from `Get-MyDevice` and `Get-MyDeviceIntune`
- bump GraphEssentials to 0.0.59 so downstream cleanup code can require the new inventory shape
- cover the Intune projection with tests

## Validation
- `Invoke-Pester -Path C:\Support\GitHub\GraphEssentials\Tests\Get-MyDeviceIntune.Tests.ps1, C:\Support\GitHub\GraphEssentials\Tests\MyDeviceLifecycleActions.Tests.ps1, C:\Support\GitHub\GraphEssentials\Tests\ModuleManifest.Tests.ps1 -CI`
