### PR TITLE
Reduce device inventory memory usage

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -93,7 +93,7 @@ Invoke-ModuleBuild -ModuleName 'GraphEssentials' {
     # when creating PSD1 use special style without comments and with only required parameters
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
     New-ConfigurationImportModule -ImportSelf
 

--- a/Private/Get-GraphEssentialsAutopilotLookup.ps1
+++ b/Private/Get-GraphEssentialsAutopilotLookup.ps1
@@ -9,12 +9,24 @@ function Get-GraphEssentialsAutopilotLookup {
 
     try {
         $properties = @(
-            'id', 'groupTag', 'purchaseOrderIdentifier', 'serialNumber', 'manufacturer', 'model',
-            'enrollmentState', 'lastContactedDateTime', 'addressableUserName', 'userPrincipalName',
-            'resourceName', 'skuNumber', 'systemFamily', 'azureActiveDirectoryDeviceId',
-            'managedDeviceId', 'displayName'
+            'id', 'groupTag', 'serialNumber', 'enrollmentState', 'lastContactedDateTime',
+            'userPrincipalName', 'resourceName', 'azureActiveDirectoryDeviceId', 'managedDeviceId'
         )
-        $autopilotDevices = @(Get-MgDeviceManagementWindowsAutopilotDeviceIdentity -All -Property $properties -ErrorAction Stop)
+        $autopilotDevices = [System.Collections.Generic.List[object]]::new()
+        Get-MgDeviceManagementWindowsAutopilotDeviceIdentity -All -Property $properties -ErrorAction Stop | ForEach-Object {
+            $autopilotDevices.Add([PSCustomObject] @{
+                    Id                           = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('Id', 'id')
+                    GroupTag                     = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('GroupTag', 'groupTag')
+                    SerialNumber                 = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('SerialNumber', 'serialNumber')
+                    EnrollmentState              = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('EnrollmentState', 'enrollmentState')
+                    LastContactedDateTime        = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('LastContactedDateTime', 'lastContactedDateTime')
+                    UserPrincipalName            = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('UserPrincipalName', 'userPrincipalName')
+                    ResourceName                 = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('ResourceName', 'resourceName')
+                    AzureActiveDirectoryDeviceId = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId')
+                    ManagedDeviceId              = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('ManagedDeviceId', 'managedDeviceId')
+                    DisplayName                  = Get-GraphEssentialsObjectProperty -InputObject $_ -Name @('DisplayName', 'displayName')
+                })
+        }
     } catch {
         Write-Warning -Message "Get-GraphEssentialsAutopilotLookup - Failed to get Windows Autopilot devices. Error: $($_.Exception.Message)"
         return [PSCustomObject] @{

--- a/Public/Get-MyDevice.ps1
+++ b/Public/Get-MyDevice.ps1
@@ -11,7 +11,7 @@
     Filter devices by type. Valid values are 'Hybrid AzureAD', 'AzureAD joined', 'AzureAD registered', and 'Not available'.
 
     .PARAMETER Synchronized
-    When specified, returns only synchronized devices (devices with OnPremisesSyncEnabled set to true).
+    Returns only synchronized devices when specified (OnPremisesSyncEnabled is true).
 
     .PARAMETER IncludeAutopilotInventory
     When specified, enriches devices with Windows Autopilot identity metadata.
@@ -57,102 +57,116 @@
         $AutopilotLookup = Get-GraphEssentialsAutopilotLookup
     }
 
+    $DeviceCache = [System.Collections.Generic.List[object]]::new()
+    $NormalizedDevices = [System.Collections.Generic.List[object]]::new()
     try {
-        $Script:DevicesDate = Get-Date
-        $Script:Devices = Get-MgDevice -All -Property $Properties -ExpandProperty RegisteredOwners -ErrorAction Stop
-    } catch {
+        Get-MgDevice -All -Property $Properties -ExpandProperty RegisteredOwners -ErrorAction Stop | ForEach-Object {
+            $Device = $_
+            if ($Device.DeviceId) {
+                $DeviceCache.Add([PSCustomObject] @{
+                        DeviceId              = $Device.DeviceId
+                        Id                    = $Device.Id
+                        OnPremisesSyncEnabled = $Device.OnPremisesSyncEnabled
+                        TrustType             = $Device.TrustType
+                    })
+            }
+
+            if ($Device.TrustType) {
+                $TrustType = $TrustTypes[$Device.TrustType]
+            }
+            else {
+                $TrustType = 'Not available'
+            }
+
+            if ($Synchronized -and -not $Device.OnPremisesSyncEnabled) {
+                return
+            }
+            if ($Type -and $Type -notcontains $TrustType) {
+                return
+            }
+
+            if ($Device.ApproximateLastSignInDateTime) {
+                $LastSeenDays = [math]::Floor((New-TimeSpan -Start $Device.ApproximateLastSignInDateTime -End $Today).TotalDays)
+            }
+            else {
+                $LastSeenDays = $null
+            }
+            if ($Device.OnPremisesLastSyncDateTime) {
+                $LastSynchronizedDays = [math]::Floor((New-TimeSpan -Start $Device.OnPremisesLastSyncDateTime -End $Today).TotalDays)
+            }
+            else {
+                $LastSynchronizedDays = $null
+            }
+
+            $OwnerDisplayName = [System.Collections.Generic.List[string]]::new()
+            $OwnerEnabled = [System.Collections.Generic.List[string]]::new()
+            $OwnerUserPrincipalName = [System.Collections.Generic.List[string]]::new()
+            foreach ($Owner in $Device.RegisteredOwners) {
+                if ($Owner.AdditionalProperties.displayName) {
+                    $OwnerDisplayName.Add($Owner.AdditionalProperties.displayName)
+                }
+                if ($null -ne $Owner.AdditionalProperties.accountEnabled) {
+                    $OwnerEnabled.Add([string] $Owner.AdditionalProperties.accountEnabled)
+                }
+                if ($Owner.AdditionalProperties.userPrincipalName) {
+                    $OwnerUserPrincipalName.Add($Owner.AdditionalProperties.userPrincipalName)
+                }
+            }
+
+            $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -AzureAdDeviceId $Device.DeviceId
+            $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
+
+            $NormalizedDevices.Add([PSCustomObject] @{
+                    Name                       = $Device.DisplayName
+                    Id                         = $Device.Id
+                    EntraDeviceObjectId        = $Device.Id
+                    Enabled                    = $Device.AccountEnabled
+                    OperatingSystem            = $Device.OperatingSystem
+                    OperatingSystemVersion     = $Device.OperatingSystemVersion
+                    TrustType                  = $TrustType
+                    ProfileType                = $Device.ProfileType
+                    FirstSeen                  = $Device.RegistrationDateTime
+                    LastSeen                   = $Device.ApproximateLastSignInDateTime
+                    LastSeenDays               = $LastSeenDays
+                    Status                     = $Device.DeviceOwnership
+                    OwnerCount                 = @($Device.RegisteredOwners).Count
+                    OwnerDisplayName           = $OwnerDisplayName
+                    OwnerEnabled               = $OwnerEnabled
+                    OwnerUserPrincipalName     = $OwnerUserPrincipalName
+                    IsSynchronized             = if ($Device.OnPremisesSyncEnabled) { $true } else { $false }
+                    LastSynchronized           = $Device.OnPremisesLastSyncDateTime
+                    LastSynchronizedDays       = $LastSynchronizedDays
+                    IsCompliant                = $Device.IsCompliant
+                    IsManaged                  = $Device.IsManaged
+                    DeviceId                   = $Device.DeviceId
+                    Model                      = $Device.Model
+                    Manufacturer               = $Device.Manufacturer
+                    ManagementType             = $Device.ManagementType
+                    EnrollmentType             = $Device.EnrollmentType
+                    AutopilotInventoryLoaded   = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
+                    AutopilotOnboarded         = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
+                    AutopilotDeviceId          = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+                    AutopilotManagedDeviceId   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
+                    AutopilotAzureAdDeviceId   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
+                    AutopilotResourceName      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
+                    AutopilotGroupTag          = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
+                    AutopilotSerialNumber      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
+                    AutopilotEnrollmentState   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
+                    AutopilotLastContacted     = $AutopilotLastContacted
+                    AutopilotLastContactedDays = $AutopilotLastContactedDays
+                    AutopilotUserPrincipalName = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
+                })
+        }
+    }
+    catch {
+        $Script:Devices = $null
+        $Script:DevicesDate = $null
         Write-Warning -Message "Get-MyDevice - Failed to get devices. Error: $($_.Exception.Message)"
         return
     }
-    foreach ($Device in $Script:Devices) {
-        if ($Device.ApproximateLastSignInDateTime) {
-            $LastSeenDays = [math]::Floor((New-TimeSpan -Start $Device.ApproximateLastSignInDateTime -End $Today).TotalDays)
-        } else {
-            $LastSeenDays = $null
-        }
-        if ($Device.OnPremisesLastSyncDateTime) {
-            $LastSynchronizedDays = [math]::Floor((New-TimeSpan -Start $Device.OnPremisesLastSyncDateTime -End $Today).TotalDays)
-        } else {
-            $LastSynchronizedDays = $null
-        }
 
-        if ($Device.TrustType) {
-            $TrustType = $TrustTypes[$Device.TrustType]
-        } else {
-            $TrustType = 'Not available'
-        }
-
-        $OwnerDisplayName = [System.Collections.Generic.List[string]]::new()
-        $OwnerEnabled = [System.Collections.Generic.List[string]]::new()
-        $OwnerUserPrincipalName = [System.Collections.Generic.List[string]]::new()
-        foreach ($Owner in $Device.RegisteredOwners) {
-            if ($Owner.AdditionalProperties.displayName) {
-                $OwnerDisplayName.Add($Owner.AdditionalProperties.displayName)
-            }
-            if ($null -ne $Owner.AdditionalProperties.accountEnabled) {
-                $OwnerEnabled.Add([string] $Owner.AdditionalProperties.accountEnabled)
-            }
-            if ($Owner.AdditionalProperties.userPrincipalName) {
-                $OwnerUserPrincipalName.Add($Owner.AdditionalProperties.userPrincipalName)
-            }
-        }
-
-        if ($Synchronized) {
-            # Only return synchronized devices
-            if (-not $Device.OnPremisesSyncEnabled) {
-                continue
-            }
-        }
-        if ($Type) {
-            # Only return devices of the specified type
-            if ($Type -notcontains $TrustType) {
-                continue
-            }
-        }
-
-        $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -AzureAdDeviceId $Device.DeviceId
-        $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
-        $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
-
-        [PSCustomObject] @{
-            Name                   = $Device.DisplayName
-            Id                     = $Device.Id
-            EntraDeviceObjectId    = $Device.Id
-            Enabled                = $Device.AccountEnabled
-            OperatingSystem        = $Device.OperatingSystem
-            OperatingSystemVersion = $Device.OperatingSystemVersion
-            TrustType              = $TrustType
-            ProfileType            = $Device.ProfileType
-            FirstSeen              = $Device.RegistrationDateTime
-            LastSeen               = $Device.ApproximateLastSignInDateTime
-            LastSeenDays           = $LastSeenDays
-            Status                 = $Device.DeviceOwnership
-            OwnerCount             = @($Device.RegisteredOwners).Count
-            OwnerDisplayName       = $OwnerDisplayName
-            OwnerEnabled           = $OwnerEnabled
-            OwnerUserPrincipalName = $OwnerUserPrincipalName
-            IsSynchronized         = if ($Device.OnPremisesSyncEnabled) { $true } else { $false }
-            LastSynchronized       = $Device.OnPremisesLastSyncDateTime
-            LastSynchronizedDays   = $LastSynchronizedDays
-            IsCompliant            = $Device.IsCompliant
-            IsManaged              = $Device.IsManaged
-            DeviceId               = $Device.DeviceId
-            Model                  = $Device.Model
-            Manufacturer           = $Device.Manufacturer
-            ManagementType         = $Device.ManagementType
-            EnrollmentType         = $Device.EnrollmentType
-            AutopilotInventoryLoaded = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
-            AutopilotOnboarded     = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
-            AutopilotDeviceId      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
-            AutopilotManagedDeviceId = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
-            AutopilotAzureAdDeviceId = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
-            AutopilotResourceName  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
-            AutopilotGroupTag      = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
-            AutopilotSerialNumber  = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
-            AutopilotEnrollmentState = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
-            AutopilotLastContacted = $AutopilotLastContacted
-            AutopilotLastContactedDays = $AutopilotLastContactedDays
-            AutopilotUserPrincipalName = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
-        }
-    }
+    $Script:Devices = $DeviceCache
+    $Script:DevicesDate = Get-Date
+    $NormalizedDevices
 }

--- a/Public/Get-MyDeviceIntune.ps1
+++ b/Public/Get-MyDeviceIntune.ps1
@@ -24,6 +24,10 @@
     .PARAMETER IncludeAutopilotInventory
     When specified, enriches managed devices with Windows Autopilot identity metadata.
 
+    .PARAMETER PropertySet
+    Selects the managed-device property projection. Full preserves the existing rich output.
+    Lifecycle requests only the fields needed for inventory correlation and lifecycle actions.
+
     .EXAMPLE
     Get-MyDeviceIntune
     Returns all Intune managed devices with their properties.
@@ -48,20 +52,21 @@
         [int] $CacheMinutes = 30,
         [switch] $Force,
         [switch] $IncludeDetailedInventory,
-        [switch] $IncludeAutopilotInventory
+        [switch] $IncludeAutopilotInventory,
+        [ValidateSet('Full', 'Lifecycle')]
+        [string] $PropertySet = 'Full'
     )
-    $CachedAzure = [ordered] @{}
+    $CachedAzure = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::OrdinalIgnoreCase)
     $Today = Get-Date
+    $LifecycleProperties = @(
+        'azureADDeviceId', 'azureADRegistered', 'complianceState', 'deviceEnrollmentType', 'deviceName',
+        'deviceRegistrationState', 'emailAddress', 'enrolledDateTime', 'id', 'lastSyncDateTime',
+        'managedDeviceOwnerType', 'managementAgent', 'operatingSystem', 'osVersion', 'serialNumber',
+        'userDisplayName', 'userPrincipalName'
+    )
     $AutopilotLookup = $null
     if ($IncludeAutopilotInventory) {
         $AutopilotLookup = Get-GraphEssentialsAutopilotLookup
-    }
-
-    try {
-        $DevicesIntune = Get-MgDeviceManagementManagedDevice -All -ErrorAction Stop
-    } catch {
-        Write-Warning -Message "Get-MyDeviceIntune - Failed to get intune devices. Error: $($_.Exception.Message)"
-        return
     }
 
     # Always build a deviceId -> Entra object id lookup so lifecycle actions can
@@ -69,28 +74,38 @@
     if ($Type -or $Synchronized) {
         try {
             if (-not $Script:Devices -or $Force -or $Script:DevicesDate -lt (Get-Date).AddMinutes(-$CacheMinutes)) {
-                $DevicesAzure = Get-MgDevice -All -Property 'deviceId,id,onPremisesSyncEnabled,trustType' -ErrorAction Stop
+                Get-MgDevice -All -Property 'deviceId,id,onPremisesSyncEnabled,trustType' -ErrorAction Stop | ForEach-Object {
+                    if ($_.DeviceId) {
+                        $CachedAzure[$_.DeviceId] = $_
+                    }
+                }
             } else {
-                $DevicesAzure = $Script:Devices
+                foreach ($DeviceA in $Script:Devices) {
+                    if ($DeviceA.DeviceId) {
+                        $CachedAzure[$DeviceA.DeviceId] = $DeviceA
+                    }
+                }
             }
         } catch {
             Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure devices. Error: $($_.Exception.Message)"
             return
         }
     } elseif ($Script:Devices -and -not $Force -and $Script:DevicesDate -ge (Get-Date).AddMinutes(-$CacheMinutes)) {
-        $DevicesAzure = $Script:Devices
+        foreach ($DeviceA in $Script:Devices) {
+            if ($DeviceA.DeviceId) {
+                $CachedAzure[$DeviceA.DeviceId] = $DeviceA
+            }
+        }
     } else {
         try {
-            $DevicesAzure = Get-MgDevice -All -Property 'deviceId,id' -ErrorAction Stop
+            Get-MgDevice -All -Property 'deviceId,id' -ErrorAction Stop | ForEach-Object {
+                if ($_.DeviceId) {
+                    $CachedAzure[$_.DeviceId] = $_
+                }
+            }
         } catch {
             Write-Warning -Message "Get-MyDeviceIntune - Failed to get Azure device identifiers. Continuing without Entra device object IDs. Error: $($_.Exception.Message)"
-            $DevicesAzure = @()
-        }
-    }
-
-    foreach ($DeviceA in $DevicesAzure) {
-        if ($DeviceA.DeviceId) {
-            $CachedAzure[$DeviceA.DeviceId] = $DeviceA
+            $CachedAzure.Clear()
         }
     }
 
@@ -100,169 +115,185 @@
         'Workplace' = 'AzureAD registered'
     }
 
-    foreach ($DeviceI in $DevicesIntune) {
-        if ($DeviceI.LastSyncDateTime) {
-            $LastSynchronizedDays = [math]::Floor((New-TimeSpan -Start $DeviceI.LastSyncDateTime -End $Today).TotalDays)
-        } else {
-            $LastSynchronizedDays = $null
+    $NormalizedDevices = [System.Collections.Generic.List[object]]::new()
+    try {
+        $ManagedDeviceParameters = @{
+            All         = $true
+            ErrorAction = 'Stop'
         }
-
-        # Get the Azure device information for the current Intune device
-        if ($CachedAzure[$DeviceI.AzureAdDeviceId]) {
-            $DeviceA = $CachedAzure[$DeviceI.AzureAdDeviceId]
-            if ($DeviceA.TrustType) {
-                $TrustType = $TrustTypes[$DeviceA.TrustType]
+        if ($PropertySet -eq 'Lifecycle') {
+            $ManagedDeviceParameters.Property = $LifecycleProperties
+        }
+        Get-MgDeviceManagementManagedDevice @ManagedDeviceParameters | ForEach-Object {
+            $DeviceI = $_
+            if ($DeviceI.LastSyncDateTime) {
+                $LastSynchronizedDays = [math]::Floor((New-TimeSpan -Start $DeviceI.LastSyncDateTime -End $Today).TotalDays)
             } else {
+                $LastSynchronizedDays = $null
+            }
+
+            # Get the Azure device information for the current Intune device
+            if ($DeviceI.AzureAdDeviceId -and $CachedAzure.ContainsKey($DeviceI.AzureAdDeviceId)) {
+                $DeviceA = $CachedAzure[$DeviceI.AzureAdDeviceId]
+                if ($DeviceA.TrustType) {
+                    $TrustType = $TrustTypes[$DeviceA.TrustType]
+                } else {
+                    $TrustType = 'Not available'
+                }
+                $SynchronizedDevice = $DeviceA.OnPremisesSyncEnabled
+            } else {
+                $DeviceA = $null
                 $TrustType = 'Not available'
+                $SynchronizedDevice = $null
             }
-            $SynchronizedDevice = $DeviceA.OnPremisesSyncEnabled
-        } else {
-            $DeviceA = $null
-            $TrustType = 'Not available'
-            $SynchronizedDevice = $null
-        }
-        if ($Type) {
-            # Only return devices of the specified type
-            if ($Type -notcontains $TrustType) {
-                continue
-            }
-        }
-        if ($Synchronized) {
-            # Only return synchronized devices
-            if (-not $SynchronizedDevice) {
-                continue
-            }
-        }
-
-        $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -ManagedDeviceId $DeviceI.Id -AzureAdDeviceId $DeviceI.AzureAdDeviceId -SerialNumber $DeviceI.SerialNumber
-        $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
-        $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
-
-        $DetailedInventoryLoaded = $false
-        $ActivationLockBypassCode = $null
-        $Iccid = $null
-        $Udid = $null
-        $Notes = $null
-        $EthernetMacAddress = $null
-        $PhysicalMemoryInBytes = $null
-        if ($IncludeDetailedInventory) {
-            try {
-                $DetailedDevice = Get-MgDeviceManagementManagedDevice -ManagedDeviceId $DeviceI.Id -Property 'activationLockBypassCode,iccid,udid,notes,ethernetMacAddress,physicalMemoryInBytes' -ErrorAction Stop
-                $ActivationLockBypassCode = $DetailedDevice.ActivationLockBypassCode
-                $Iccid = $DetailedDevice.Iccid
-                $Udid = $DetailedDevice.Udid
-                $Notes = $DetailedDevice.Notes
-                $EthernetMacAddress = $DetailedDevice.EthernetMacAddress
-                $PhysicalMemoryInBytes = $DetailedDevice.PhysicalMemoryInBytes
-                $DetailedInventoryLoaded = $true
-            } catch {
-                Write-Warning -Message "Get-MyDeviceIntune - Failed to get detailed inventory for $($DeviceI.DeviceName). Error: $($_.Exception.Message)"
-            }
-        }
-
-        $DeviceInformation = [ordered] @{
-            Name                                    = $DeviceI.DeviceName                                # : EVOMONSTER
-            Id                                      = $DeviceI.Id                                        # : 83fe122f-c51c-49dc-a0f3-cc11d9e7d045
-            ManagedDeviceId                         = $DeviceI.Id
-            EntraDeviceObjectId                     = if ($DeviceA) { $DeviceA.Id } else { $null }
-            ComplianceState                         = $DeviceI.ComplianceState                           # : compliant
-            OperatingSystem                         = $DeviceI.OperatingSystem                           # : Windows
-            OperatingSystemVersion                  = $DeviceI.OSVersion                                 # : 10.0.22621.1555
-            FirstSeen                               = $DeviceI.EnrolledDateTime                          # : 2023-01-28 10:34:18
-            LastSeen                                = $DeviceI.LastSyncDateTime                          # : 2023-04-14 04:52:42
-            LastSeenDays                            = $LastSynchronizedDays
-            UserDisplayName                         = $DeviceI.UserDisplayName                           # : Przemysław Kłys
-            UserId                                  = $DeviceI.UserId                                    # : e6a8f1cf-0874-4323-a12f-2bf51bb6dfdd
-            UserPrincipalName                       = $DeviceI.UserPrincipalName                         # : przemyslaw.klys@evotec.pl
-            EmailAddress                            = $DeviceI.EmailAddress                              # : przemyslaw.klys@evotec.pl
-            ManagedDeviceName                       = $DeviceI.ManagedDeviceName                         # : przemyslaw.klys_Windows_1/28/2023_10:34 AM
-            ManagedDeviceOwnerType                  = $DeviceI.ManagedDeviceOwnerType                    # : company
-            ManagementAgent                         = $DeviceI.ManagementAgent                           # : mdm
-            ManagementCertificateExpirationDate     = $DeviceI.ManagementCertificateExpirationDate       # : 2024-01-27 17:58:15
-            AndroidSecurityPatchLevel               = $DeviceI.AndroidSecurityPatchLevel                 # :
-            AzureAdDeviceId                         = $DeviceI.AzureAdDeviceId                           # : aee87706-674b-40be-8120-74e7c469329b
-            AzureAdRegistered                       = $DeviceI.AzureAdRegistered                         # : True
-            ComplianceGracePeriodExpirationDateTime = $DeviceI.ComplianceGracePeriodExpirationDateTime   # : 9999-12-31 23:59:59
-
-            #ConfigurationManagerClientEnabledFeatures = $DeviceI.ConfigurationManagerClientEnabledFeatures # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphConfigurationManagerClientEnabledFeatures
-            DeviceActionResults                     = $DeviceI.DeviceActionResults                       # : {}
-            #DeviceCategory                            = $DeviceI.DeviceCategory                            # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphDeviceCategory
-            DeviceCategoryName                      = $DeviceI.DeviceCategoryDisplayName                 # : Unknown
-            DeviceCompliancePolicyStates            = $DeviceI.DeviceCompliancePolicyStates              # :
-            DeviceConfigurationStates               = $DeviceI.DeviceConfigurationStates                 # :
-            DeviceEnrollmentType                    = $DeviceI.DeviceEnrollmentType                      # : windowsCoManagement
-            #DeviceHealthAttestationState              = $DeviceI.DeviceHealthAttestationState              # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphDeviceHealthAttestationState
-            DeviceRegistrationState                 = $DeviceI.DeviceRegistrationState                   # : registered
-            EasActivated                            = $DeviceI.EasActivated                              # : True
-            EasActivationDateTime                   = $DeviceI.EasActivationDateTime                     # : 0001-01-01 00:00:00
-            EasDeviceId                             = $DeviceI.EasDeviceId                               # : E88398D87BD859566D129F86E2FD722C
-            ExchangeAccessState                     = $DeviceI.ExchangeAccessState                       # : none
-            ExchangeAccessStateReason               = $DeviceI.ExchangeAccessStateReason                 # : none
-            ExchangeLastSuccessfulSyncDateTime      = $DeviceI.ExchangeLastSuccessfulSyncDateTime        # : 0001-01-01 00:00:00
-            FreeStorageSpaceInBytes                 = $DeviceI.FreeStorageSpaceInBytes                   # : 1392111517696
-            Imei                                    = $DeviceI.Imei                                      # :
-            IsEncrypted                             = $DeviceI.IsEncrypted                               # : True
-            IsSupervised                            = $DeviceI.IsSupervised                              # : False
-            IsJailBroken                            = $DeviceI.JailBroken                                # : Unknown
-            Manufacturer                            = $DeviceI.Manufacturer                              # : ASUS
-            Meid                                    = $DeviceI.Meid                                      # :
-            Model                                   = $DeviceI.Model                                     # : System Product Name
-            PartnerReportedThreatState              = $DeviceI.PartnerReportedThreatState                # : unknown
-            PhoneNumber                             = $DeviceI.PhoneNumber                               # :
-            SerialNumber                            = $DeviceI.SerialNumber                              # : SystemSerialNumber
-            SubscriberCarrier                       = $DeviceI.SubscriberCarrier                         # :
-            TotalStorageSpaceInBytes                = $DeviceI.TotalStorageSpaceInBytes                  # : 1999609266176
-            Users                                   = $DeviceI.Users                                     # :
-            WiFiMacAddress                          = $DeviceI.WiFiMacAddress                            # : 8C1D96F0937B
-            RemoteAssistanceSessionErrorDetails     = $DeviceI.RemoteAssistanceSessionErrorDetails       # :
-            RemoteAssistanceSessionUrl              = $DeviceI.RemoteAssistanceSessionUrl                # :
-            RequireUserEnrollmentApproval           = $DeviceI.RequireUserEnrollmentApproval             # :
-            DetailedInventoryLoaded                 = $DetailedInventoryLoaded
-            ActivationLockBypassCode                = $ActivationLockBypassCode
-            EthernetMacAddress                      = $EthernetMacAddress
-            Iccid                                   = $Iccid
-            Notes                                   = $Notes
-            PhysicalMemoryInBytes                   = $PhysicalMemoryInBytes
-            Udid                                    = $Udid
-            AutopilotInventoryLoaded                = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
-            AutopilotOnboarded                      = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
-            AutopilotDeviceId                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
-            AutopilotManagedDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
-            AutopilotAzureAdDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
-            AutopilotResourceName                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
-            AutopilotGroupTag                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
-            AutopilotSerialNumber                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
-            AutopilotEnrollmentState                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
-            AutopilotLastContacted                  = $AutopilotLastContacted
-            AutopilotLastContactedDays              = $AutopilotLastContactedDays
-            AutopilotUserPrincipalName              = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
-            #AdditionalProperties                      = $DeviceI.AdditionalProperties                      # : {}
-        }
-        if ($Type -or $Synchronized) {
-            $DeviceInformation['TrustType'] = $TrustType
-            $DeviceInformation['IsSynchronized'] = $SynchronizedDevice
-        }
-        if ($DeviceI.ConfigurationManagerClientEnabledFeatures) {
-            foreach ($D in $DeviceI.ConfigurationManagerClientEnabledFeatures.PSObject.Properties) {
-                if ($D.Name -notin 'AdditionalProperties') {
-                    $DeviceInformation["ConfigurationManagerClientEnabledFeatures$($D.Name)"] = $D.Value
+            if ($Type) {
+                # Only return devices of the specified type
+                if ($Type -notcontains $TrustType) {
+                    return
                 }
             }
-        }
-        if ($DeviceI.DeviceCategory) {
-            foreach ($D in $DeviceI.DeviceCategory.PSObject.Properties) {
-                if ($D.Name -notin 'AdditionalProperties') {
-                    $DeviceInformation["DeviceCategory$($D.Name)"] = $D.Value
+            if ($Synchronized) {
+                # Only return synchronized devices
+                if (-not $SynchronizedDevice) {
+                    return
                 }
             }
-        }
-        if ($DeviceI.DeviceHealthAttestationState) {
-            foreach ($D in $DeviceI.DeviceHealthAttestationState.PSObject.Properties) {
-                if ($D.Name -notin 'AdditionalProperties') {
-                    $DeviceInformation["DeviceHealthAttestationState$($D.Name)"] = $D.Value
+
+            $AutopilotDevice = Find-GraphEssentialsAutopilotDevice -Lookup $AutopilotLookup -ManagedDeviceId $DeviceI.Id -AzureAdDeviceId $DeviceI.AzureAdDeviceId -SerialNumber $DeviceI.SerialNumber
+            $AutopilotLastContacted = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('LastContactedDateTime', 'lastContactedDateTime') } else { $null }
+            $AutopilotLastContactedDays = if ($AutopilotLastContacted) { [math]::Floor((New-TimeSpan -Start $AutopilotLastContacted -End $Today).TotalDays) } else { $null }
+
+            $DetailedInventoryLoaded = $false
+            $ActivationLockBypassCode = $null
+            $Iccid = $null
+            $Udid = $null
+            $Notes = $null
+            $EthernetMacAddress = $null
+            $PhysicalMemoryInBytes = $null
+            if ($IncludeDetailedInventory) {
+                try {
+                    $DetailedDevice = Get-MgDeviceManagementManagedDevice -ManagedDeviceId $DeviceI.Id -Property 'activationLockBypassCode,iccid,udid,notes,ethernetMacAddress,physicalMemoryInBytes' -ErrorAction Stop
+                    $ActivationLockBypassCode = $DetailedDevice.ActivationLockBypassCode
+                    $Iccid = $DetailedDevice.Iccid
+                    $Udid = $DetailedDevice.Udid
+                    $Notes = $DetailedDevice.Notes
+                    $EthernetMacAddress = $DetailedDevice.EthernetMacAddress
+                    $PhysicalMemoryInBytes = $DetailedDevice.PhysicalMemoryInBytes
+                    $DetailedInventoryLoaded = $true
+                } catch {
+                    Write-Warning -Message "Get-MyDeviceIntune - Failed to get detailed inventory for $($DeviceI.DeviceName). Error: $($_.Exception.Message)"
                 }
             }
+
+            $DeviceInformation = [ordered] @{
+                Name                                    = $DeviceI.DeviceName                                # : EVOMONSTER
+                Id                                      = $DeviceI.Id                                        # : 83fe122f-c51c-49dc-a0f3-cc11d9e7d045
+                ManagedDeviceId                         = $DeviceI.Id
+                EntraDeviceObjectId                     = if ($DeviceA) { $DeviceA.Id } else { $null }
+                ComplianceState                         = $DeviceI.ComplianceState                           # : compliant
+                OperatingSystem                         = $DeviceI.OperatingSystem                           # : Windows
+                OperatingSystemVersion                  = $DeviceI.OSVersion                                 # : 10.0.22621.1555
+                FirstSeen                               = $DeviceI.EnrolledDateTime                          # : 2023-01-28 10:34:18
+                LastSeen                                = $DeviceI.LastSyncDateTime                          # : 2023-04-14 04:52:42
+                LastSeenDays                            = $LastSynchronizedDays
+                UserDisplayName                         = $DeviceI.UserDisplayName                           # : Przemysław Kłys
+                UserId                                  = $DeviceI.UserId                                    # : e6a8f1cf-0874-4323-a12f-2bf51bb6dfdd
+                UserPrincipalName                       = $DeviceI.UserPrincipalName                         # : przemyslaw.klys@evotec.pl
+                EmailAddress                            = $DeviceI.EmailAddress                              # : przemyslaw.klys@evotec.pl
+                ManagedDeviceName                       = $DeviceI.ManagedDeviceName                         # : przemyslaw.klys_Windows_1/28/2023_10:34 AM
+                ManagedDeviceOwnerType                  = $DeviceI.ManagedDeviceOwnerType                    # : company
+                ManagementAgent                         = $DeviceI.ManagementAgent                           # : mdm
+                ManagementCertificateExpirationDate     = $DeviceI.ManagementCertificateExpirationDate       # : 2024-01-27 17:58:15
+                AndroidSecurityPatchLevel               = $DeviceI.AndroidSecurityPatchLevel                 # :
+                AzureAdDeviceId                         = $DeviceI.AzureAdDeviceId                           # : aee87706-674b-40be-8120-74e7c469329b
+                AzureAdRegistered                       = $DeviceI.AzureAdRegistered                         # : True
+                ComplianceGracePeriodExpirationDateTime = $DeviceI.ComplianceGracePeriodExpirationDateTime   # : 9999-12-31 23:59:59
+
+                #ConfigurationManagerClientEnabledFeatures = $DeviceI.ConfigurationManagerClientEnabledFeatures # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphConfigurationManagerClientEnabledFeatures
+                DeviceActionResults                     = $DeviceI.DeviceActionResults                       # : {}
+                #DeviceCategory                            = $DeviceI.DeviceCategory                            # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphDeviceCategory
+                DeviceCategoryName                      = $DeviceI.DeviceCategoryDisplayName                 # : Unknown
+                DeviceCompliancePolicyStates            = $DeviceI.DeviceCompliancePolicyStates              # :
+                DeviceConfigurationStates               = $DeviceI.DeviceConfigurationStates                 # :
+                DeviceEnrollmentType                    = $DeviceI.DeviceEnrollmentType                      # : windowsCoManagement
+                #DeviceHealthAttestationState              = $DeviceI.DeviceHealthAttestationState              # : Microsoft.Graph.PowerShell.Models.MicrosoftGraphDeviceHealthAttestationState
+                DeviceRegistrationState                 = $DeviceI.DeviceRegistrationState                   # : registered
+                EasActivated                            = $DeviceI.EasActivated                              # : True
+                EasActivationDateTime                   = $DeviceI.EasActivationDateTime                     # : 0001-01-01 00:00:00
+                EasDeviceId                             = $DeviceI.EasDeviceId                               # : E88398D87BD859566D129F86E2FD722C
+                ExchangeAccessState                     = $DeviceI.ExchangeAccessState                       # : none
+                ExchangeAccessStateReason               = $DeviceI.ExchangeAccessStateReason                 # : none
+                ExchangeLastSuccessfulSyncDateTime      = $DeviceI.ExchangeLastSuccessfulSyncDateTime        # : 0001-01-01 00:00:00
+                FreeStorageSpaceInBytes                 = $DeviceI.FreeStorageSpaceInBytes                   # : 1392111517696
+                Imei                                    = $DeviceI.Imei                                      # :
+                IsEncrypted                             = $DeviceI.IsEncrypted                               # : True
+                IsSupervised                            = $DeviceI.IsSupervised                              # : False
+                IsJailBroken                            = $DeviceI.JailBroken                                # : Unknown
+                Manufacturer                            = $DeviceI.Manufacturer                              # : ASUS
+                Meid                                    = $DeviceI.Meid                                      # :
+                Model                                   = $DeviceI.Model                                     # : System Product Name
+                PartnerReportedThreatState              = $DeviceI.PartnerReportedThreatState                # : unknown
+                PhoneNumber                             = $DeviceI.PhoneNumber                               # :
+                SerialNumber                            = $DeviceI.SerialNumber                              # : SystemSerialNumber
+                SubscriberCarrier                       = $DeviceI.SubscriberCarrier                         # :
+                TotalStorageSpaceInBytes                = $DeviceI.TotalStorageSpaceInBytes                  # : 1999609266176
+                Users                                   = $DeviceI.Users                                     # :
+                WiFiMacAddress                          = $DeviceI.WiFiMacAddress                            # : 8C1D96F0937B
+                RemoteAssistanceSessionErrorDetails     = $DeviceI.RemoteAssistanceSessionErrorDetails       # :
+                RemoteAssistanceSessionUrl              = $DeviceI.RemoteAssistanceSessionUrl                # :
+                RequireUserEnrollmentApproval           = $DeviceI.RequireUserEnrollmentApproval             # :
+                DetailedInventoryLoaded                 = $DetailedInventoryLoaded
+                ActivationLockBypassCode                = $ActivationLockBypassCode
+                EthernetMacAddress                      = $EthernetMacAddress
+                Iccid                                   = $Iccid
+                Notes                                   = $Notes
+                PhysicalMemoryInBytes                   = $PhysicalMemoryInBytes
+                Udid                                    = $Udid
+                AutopilotInventoryLoaded                = if ($IncludeAutopilotInventory) { [bool] $AutopilotLookup.InventoryLoaded } else { $false }
+                AutopilotOnboarded                      = if ($IncludeAutopilotInventory -and $AutopilotLookup.InventoryLoaded) { [bool] $AutopilotDevice } else { $null }
+                AutopilotDeviceId                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('Id', 'id') } else { $null }
+                AutopilotManagedDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ManagedDeviceId', 'managedDeviceId') } else { $null }
+                AutopilotAzureAdDeviceId                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('AzureAdDeviceId', 'azureAdDeviceId', 'AzureActiveDirectoryDeviceId', 'azureActiveDirectoryDeviceId') } else { $null }
+                AutopilotResourceName                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('ResourceName', 'resourceName', 'DisplayName', 'displayName') } else { $null }
+                AutopilotGroupTag                       = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('GroupTag', 'groupTag') } else { $null }
+                AutopilotSerialNumber                   = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('SerialNumber', 'serialNumber') } else { $null }
+                AutopilotEnrollmentState                = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('EnrollmentState', 'enrollmentState') } else { $null }
+                AutopilotLastContacted                  = $AutopilotLastContacted
+                AutopilotLastContactedDays              = $AutopilotLastContactedDays
+                AutopilotUserPrincipalName              = if ($AutopilotDevice) { Get-GraphEssentialsObjectProperty -InputObject $AutopilotDevice -Name @('UserPrincipalName', 'userPrincipalName') } else { $null }
+                #AdditionalProperties                      = $DeviceI.AdditionalProperties                      # : {}
+            }
+            if ($Type -or $Synchronized) {
+                $DeviceInformation['TrustType'] = $TrustType
+                $DeviceInformation['IsSynchronized'] = $SynchronizedDevice
+            }
+            if ($DeviceI.ConfigurationManagerClientEnabledFeatures) {
+                foreach ($D in $DeviceI.ConfigurationManagerClientEnabledFeatures.PSObject.Properties) {
+                    if ($D.Name -notin 'AdditionalProperties') {
+                        $DeviceInformation["ConfigurationManagerClientEnabledFeatures$($D.Name)"] = $D.Value
+                    }
+                }
+            }
+            if ($DeviceI.DeviceCategory) {
+                foreach ($D in $DeviceI.DeviceCategory.PSObject.Properties) {
+                    if ($D.Name -notin 'AdditionalProperties') {
+                        $DeviceInformation["DeviceCategory$($D.Name)"] = $D.Value
+                    }
+                }
+            }
+            if ($DeviceI.DeviceHealthAttestationState) {
+                foreach ($D in $DeviceI.DeviceHealthAttestationState.PSObject.Properties) {
+                    if ($D.Name -notin 'AdditionalProperties') {
+                        $DeviceInformation["DeviceHealthAttestationState$($D.Name)"] = $D.Value
+                    }
+                }
+            }
+            $NormalizedDevices.Add([PSCustomObject] $DeviceInformation)
         }
-        [PSCustomObject] $DeviceInformation
+    } catch {
+        Write-Warning -Message "Get-MyDeviceIntune - Failed to get intune devices. Error: $($_.Exception.Message)"
+        return
     }
+
+    $NormalizedDevices
 }

--- a/Tests/Get-MyDevice.Tests.ps1
+++ b/Tests/Get-MyDevice.Tests.ps1
@@ -1,0 +1,98 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Public\Get-MyDevice.ps1')
+
+    function Get-MgDevice {
+        param([switch] $All, $Property, $ExpandProperty, $ErrorAction)
+    }
+    function Find-GraphEssentialsAutopilotDevice { $null }
+    function Get-GraphEssentialsAutopilotLookup { $null }
+}
+
+Describe 'Get-MyDevice' {
+    BeforeEach {
+        $script:Devices = $null
+        $script:DevicesDate = $null
+
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    AccountEnabled                = $true
+                    ApproximateLastSignInDateTime = (Get-Date).AddDays(-10)
+                    DeviceId                      = 'device-1'
+                    DisplayName                   = 'DEVICE-01'
+                    Id                            = 'object-1'
+                    OnPremisesSyncEnabled         = $false
+                    OperatingSystem               = 'Windows'
+                    RegisteredOwners              = @(
+                        [PSCustomObject] @{
+                            AdditionalProperties = @{
+                                accountEnabled    = $true
+                                displayName       = 'User One'
+                                userPrincipalName = 'user.one@contoso.com'
+                            }
+                        }
+                    )
+                    TrustType                     = 'Workplace'
+                }
+            )
+        }
+    }
+
+    It 'retains only compact Entra correlation metadata in the shared cache' {
+        $devices = @(Get-MyDevice)
+
+        $devices | Should -HaveCount 1
+        $devices[0].Name | Should -Be 'DEVICE-01'
+        $devices[0].OwnerUserPrincipalName | Should -Be @('user.one@contoso.com')
+        @($script:Devices) | Should -HaveCount 1
+        $script:Devices[0].PSObject.Properties.Name | Should -Be @(
+            'DeviceId'
+            'Id'
+            'OnPremisesSyncEnabled'
+            'TrustType'
+        )
+        $script:Devices[0].PSObject.Properties.Name | Should -Not -Contain 'RegisteredOwners'
+        $script:DevicesDate | Should -Not -BeNullOrEmpty
+    }
+
+    It 'does not expand owner metadata for devices excluded by join type' {
+        $additionalProperties = [PSCustomObject] @{}
+        $additionalProperties | Add-Member -MemberType ScriptProperty -Name displayName -Value { throw 'owner metadata should not be read' }
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceId          = 'device-filtered'
+                    Id                = 'object-filtered'
+                    RegisteredOwners  = @([PSCustomObject] @{ AdditionalProperties = $additionalProperties })
+                    TrustType         = 'Workplace'
+                }
+            )
+        }
+
+        $devices = @(Get-MyDevice -Type 'AzureAD joined')
+
+        $devices | Should -HaveCount 0
+        @($script:Devices) | Should -HaveCount 1
+    }
+
+    It 'does not emit a partial inventory or cache when Graph enumeration fails' {
+        Mock Get-MgDevice {
+            [PSCustomObject] @{
+                DeviceId         = 'device-partial'
+                DisplayName      = 'PARTIAL'
+                Id               = 'object-partial'
+                RegisteredOwners = @()
+                TrustType        = 'Workplace'
+            }
+            throw 'page two failed'
+        }
+
+        $warning = $null
+        $devices = @(Get-MyDevice -WarningAction SilentlyContinue -WarningVariable warning)
+
+        $devices | Should -HaveCount 0
+        $script:Devices | Should -BeNullOrEmpty
+        $script:DevicesDate | Should -BeNullOrEmpty
+        [string] $warning | Should -Match 'page two failed'
+    }
+}

--- a/Tests/Get-MyDeviceIntune.Tests.ps1
+++ b/Tests/Get-MyDeviceIntune.Tests.ps1
@@ -5,9 +5,9 @@ BeforeAll {
     . (Join-Path $PSScriptRoot '..\Private\Find-GraphEssentialsAutopilotDevice.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyDeviceIntune.ps1')
 
-    function Get-MgDeviceManagementManagedDevice {}
-    function Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {}
-    function Get-MgDevice {}
+    function Get-MgDeviceManagementManagedDevice { param([switch] $All, $Property, $ManagedDeviceId, $ErrorAction) }
+    function Get-MgDeviceManagementWindowsAutopilotDeviceIdentity { param([switch] $All, $Property, $ErrorAction) }
+    function Get-MgDevice { param([switch] $All, $Property, $ErrorAction) }
 }
 
 Describe 'Get-MyDeviceIntune' {
@@ -67,6 +67,86 @@ Describe 'Get-MyDeviceIntune' {
         $devices.Count | Should -Be 1
         $devices[0].EntraDeviceObjectId | Should -Be 'entra-1'
         $devices[0].TrustType | Should -Be 'AzureAD registered'
+    }
+
+    It 'continues type-filtered enumeration after a rejected managed device' {
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceId              = 'device-rejected'
+                    Id                    = 'entra-rejected'
+                    TrustType             = 'AzureAD'
+                    OnPremisesSyncEnabled = $false
+                }
+                [PSCustomObject] @{
+                    DeviceId              = 'device-matching'
+                    Id                    = 'entra-matching'
+                    TrustType             = 'Workplace'
+                    OnPremisesSyncEnabled = $false
+                }
+            )
+        }
+        Mock Get-MgDeviceManagementManagedDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceName       = 'Rejected'
+                    Id               = 'managed-rejected'
+                    AzureAdDeviceId  = 'device-rejected'
+                    LastSyncDateTime = (Get-Date).AddDays(-20)
+                }
+                [PSCustomObject] @{
+                    DeviceName       = 'Matching'
+                    Id               = 'managed-matching'
+                    AzureAdDeviceId  = 'device-matching'
+                    LastSyncDateTime = (Get-Date).AddDays(-10)
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -Type 'AzureAD registered' -Force)
+
+        $devices | Should -HaveCount 1
+        $devices[0].ManagedDeviceId | Should -Be 'managed-matching'
+    }
+
+    It 'continues synchronized filtering after an unsynchronized managed device' {
+        Mock Get-MgDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceId              = 'device-unsynchronized'
+                    Id                    = 'entra-unsynchronized'
+                    TrustType             = 'AzureAD'
+                    OnPremisesSyncEnabled = $false
+                }
+                [PSCustomObject] @{
+                    DeviceId              = 'device-synchronized'
+                    Id                    = 'entra-synchronized'
+                    TrustType             = 'ServerAD'
+                    OnPremisesSyncEnabled = $true
+                }
+            )
+        }
+        Mock Get-MgDeviceManagementManagedDevice {
+            @(
+                [PSCustomObject] @{
+                    DeviceName       = 'Unsynchronized'
+                    Id               = 'managed-unsynchronized'
+                    AzureAdDeviceId  = 'device-unsynchronized'
+                    LastSyncDateTime = (Get-Date).AddDays(-20)
+                }
+                [PSCustomObject] @{
+                    DeviceName       = 'Synchronized'
+                    Id               = 'managed-synchronized'
+                    AzureAdDeviceId  = 'device-synchronized'
+                    LastSyncDateTime = (Get-Date).AddDays(-10)
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -Synchronized -Force)
+
+        $devices | Should -HaveCount 1
+        $devices[0].ManagedDeviceId | Should -Be 'managed-synchronized'
     }
 
     It 'continues Intune enumeration when the default Entra lookup fails' {
@@ -175,5 +255,82 @@ Describe 'Get-MyDeviceIntune' {
         $devices[0].AutopilotInventoryLoaded | Should -BeTrue
         $devices[0].AutopilotOnboarded | Should -BeFalse
         $devices[0].AutopilotDeviceId | Should -Be $null
+    }
+
+    It 'uses the compact lifecycle projection when explicitly requested' {
+        $script:CapturedManagedDeviceProperties = $null
+        Mock Get-MgDeviceManagementManagedDevice {
+            param($Property)
+            $script:CapturedManagedDeviceProperties = @($Property)
+            @(
+                [PSCustomObject] @{
+                    DeviceName       = 'iPhone-01'
+                    Id               = 'managed-1'
+                    AzureAdDeviceId  = 'device-1'
+                    LastSyncDateTime = (Get-Date).AddDays(-10)
+                    OperatingSystem  = 'iOS'
+                    OSVersion        = '17.0'
+                }
+            )
+        }
+
+        $devices = @(Get-MyDeviceIntune -PropertySet Lifecycle -Force)
+
+        $devices | Should -HaveCount 1
+        $script:CapturedManagedDeviceProperties | Should -Contain 'azureADDeviceId'
+        $script:CapturedManagedDeviceProperties | Should -Contain 'deviceRegistrationState'
+        $script:CapturedManagedDeviceProperties | Should -Contain 'serialNumber'
+        $script:CapturedManagedDeviceProperties | Should -Not -Contain 'deviceActionResults'
+        $script:CapturedManagedDeviceProperties | Should -Not -Contain 'remoteAssistanceSessionUrl'
+    }
+
+    It 'preserves the existing unprojected managed-device query by default' {
+        $script:CapturedManagedDeviceProperties = $null
+        $script:ManagedDevicePropertyWasBound = $null
+        Mock Get-MgDeviceManagementManagedDevice {
+            param($Property)
+            $script:CapturedManagedDeviceProperties = @($Property)
+            $script:ManagedDevicePropertyWasBound = $PSBoundParameters.ContainsKey('Property')
+            @()
+        }
+
+        Get-MyDeviceIntune -Force | Out-Null
+
+        $script:ManagedDevicePropertyWasBound | Should -BeFalse
+    }
+
+    It 'does not emit partial managed-device output when Graph enumeration fails' {
+        Mock Get-MgDeviceManagementManagedDevice {
+            [PSCustomObject] @{
+                DeviceName       = 'Partial-Device'
+                Id               = 'managed-partial'
+                AzureAdDeviceId  = 'device-partial'
+                LastSyncDateTime = (Get-Date).AddDays(-10)
+            }
+            throw 'managed-device page two failed'
+        }
+
+        $warning = $null
+        $devices = @(Get-MyDeviceIntune -Force -WarningAction SilentlyContinue -WarningVariable warning)
+
+        $devices | Should -HaveCount 0
+        [string] $warning | Should -Match 'managed-device page two failed'
+    }
+
+    It 'requests only Autopilot properties used by device inventory output' {
+        $script:CapturedAutopilotProperties = $null
+        Mock Get-MgDeviceManagementWindowsAutopilotDeviceIdentity {
+            param($Property)
+            $script:CapturedAutopilotProperties = @($Property)
+            @()
+        }
+
+        Get-MyDeviceIntune -IncludeAutopilotInventory -Force | Out-Null
+
+        $script:CapturedAutopilotProperties | Should -Contain 'managedDeviceId'
+        $script:CapturedAutopilotProperties | Should -Contain 'lastContactedDateTime'
+        $script:CapturedAutopilotProperties | Should -Not -Contain 'manufacturer'
+        $script:CapturedAutopilotProperties | Should -Not -Contain 'purchaseOrderIdentifier'
+        $script:CapturedAutopilotProperties | Should -Not -Contain 'displayName'
     }
 }


### PR DESCRIPTION
## Summary

- stream Microsoft Entra and Intune device enumeration while buffering only normalized output
- retain a compact Entra correlation cache instead of full Graph SDK objects
- add an additive Get-MyDeviceIntune PropertySet contract with Full as the compatible default and Lifecycle for cleanup consumers
- request only inventory fields used by the Autopilot correlation layer
- keep Graph pagination failures fail-closed without partial output

## Compatibility

Existing Get-MyDeviceIntune callers retain the default full Graph query and output shape. Lifecycle is opt-in and is available to CleanupMonster in the published GraphEssentials 0.0.57 release.

## Scale evidence

A synthetic 100,000-device Get-MyDevice run retained all 100,000 output/cache records while reducing managed memory by 27.6% and peak working set by 23.5%.

PowerShell 7 and Windows PowerShell 5.1 regression suites pass.
