### PR TITLE
Fix Teams ownership and license reporting

### DIFF
--- a/GraphEssentials.psd1
+++ b/GraphEssentials.psd1
@@ -8,7 +8,7 @@
     Description          = 'GraphEssentials is a PowerShell module that helps with Office 365 / Azure AD using mostly Graph'
     FunctionsToExport    = @('Disable-MyDevice', 'Get-MgToken', 'Get-MyApp', 'Get-MyAppCredentials', 'Get-MyConditionalAccess', 'Get-MyDefenderDeploymentKey', 'Get-MyDefenderHealthIssues', 'Get-MyDefenderSecureScore', 'Get-MyDefenderSecureScoreProfile', 'Get-MyDefenderSensor', 'Get-MyDefenderSummary', 'Get-MyDevice', 'Get-MyDeviceIntune', 'Get-MyGuest', 'Get-MyLicense', 'Get-MyRole', 'Get-MyRoleHistory', 'Get-MyRoleUsers', 'Get-MyTeam', 'Get-MyTenantName', 'Get-MyUsageReports', 'Get-MyUser', 'Get-MyUserAuthentication', 'Invoke-MyDeviceRetire', 'Invoke-MyGraphEssentials', 'Invoke-MyGraphUsageReports', 'New-MyApp', 'New-MyAppCredentials', 'Register-FIDO2Key', 'Remove-MyAppCredentials', 'Remove-MyAutopilotDevice', 'Remove-MyDevice', 'Remove-MyDeviceIntuneRecord', 'Send-MyApp', 'Show-MyApp', 'Show-MyConditionalAccess', 'Show-MyDefender', 'Show-MyRole', 'Show-MyUserAuthentication')
     GUID                 = '75ef812f-6d8e-4898-81bb-8029e0560ef3'
-    ModuleVersion        = '0.0.57'
+    ModuleVersion        = '0.0.59'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Configuration.Teams.ps1
+++ b/Private/Configuration.Teams.ps1
@@ -13,7 +13,10 @@ $Script:Teams = [ordered] @{
         $publicTeams = 0
         $privateTeams = 0
         $teamsWithGuests = 0
+        $teamsWithoutGuests = 0
+        $guestStateUnavailable = 0
         $ownerlessTeams = 0
+        $ownerStateUnavailable = 0
         $multiOwnerTeams = 0
         $guestControlsEnabled = 0
         $guestDeleteEnabled = 0
@@ -42,14 +45,20 @@ $Script:Teams = [ordered] @{
                 $privateTeams++
             }
 
-            if ($team.HasGuests) {
+            if ($team.HasGuests -eq $true) {
                 $teamsWithGuests++
                 $teamsWithGuestsList.Add($team)
+            } elseif ($team.HasGuests -eq $false) {
+                $teamsWithoutGuests++
+            } else {
+                $guestStateUnavailable++
             }
 
-            if (-not $team.HasOwners) {
+            if ($team.HasOwners -eq $false) {
                 $ownerlessTeams++
                 $ownerlessTeamsList.Add($team)
+            } elseif ($null -eq $team.HasOwners) {
+                $ownerStateUnavailable++
             }
 
             if ($team.HasMultipleOwners) {
@@ -89,8 +98,10 @@ $Script:Teams = [ordered] @{
             }
 
             $reviewFlags = [System.Collections.Generic.List[string]]::new()
-            if (-not $team.HasOwners) {
+            if ($team.HasOwners -eq $false) {
                 $reviewFlags.Add('No owners')
+            } elseif ($null -eq $team.HasOwners) {
+                $reviewFlags.Add('Owner state unavailable')
             }
             if ($team.IsPublic) {
                 $reviewFlags.Add('Public team')
@@ -119,7 +130,10 @@ $Script:Teams = [ordered] @{
                 PublicTeams            = $publicTeams
                 PrivateTeams           = $privateTeams
                 TeamsWithGuests        = $teamsWithGuests
+                TeamsWithoutGuests     = $teamsWithoutGuests
+                GuestStateUnavailable  = $guestStateUnavailable
                 OwnerlessTeams         = $ownerlessTeams
+                OwnerStateUnavailable  = $ownerStateUnavailable
                 MultiOwnerTeams        = $multiOwnerTeams
                 GuestControlsEnabled   = $guestControlsEnabled
                 GuestDeleteEnabled     = $guestDeleteEnabled
@@ -141,7 +155,8 @@ $Script:Teams = [ordered] @{
 
         $guestDistribution = @(
             [PSCustomObject]@{ Name = 'Teams with guests'; Count = $teamsWithGuests }
-            [PSCustomObject]@{ Name = 'Teams without guests'; Count = $totalTeams - $teamsWithGuests }
+            [PSCustomObject]@{ Name = 'Teams without guests'; Count = $teamsWithoutGuests }
+            [PSCustomObject]@{ Name = 'Guest state unavailable'; Count = $guestStateUnavailable }
             [PSCustomObject]@{ Name = 'Guest controls enabled'; Count = $guestControlsEnabled }
             [PSCustomObject]@{ Name = 'Guest delete enabled'; Count = $guestDeleteEnabled }
         )
@@ -150,6 +165,7 @@ $Script:Teams = [ordered] @{
             [PSCustomObject]@{ Name = 'Ownerless'; Count = $ownerlessTeams }
             [PSCustomObject]@{ Name = 'Single owner'; Count = @($teamData.Where({ $_.OwnerCount -eq 1 })).Count }
             [PSCustomObject]@{ Name = 'Multiple owners'; Count = $multiOwnerTeams }
+            [PSCustomObject]@{ Name = 'Owner state unavailable'; Count = $ownerStateUnavailable }
         )
 
         $collaborationDistribution = @(

--- a/Private/Configuration.Teams.ps1
+++ b/Private/Configuration.Teams.ps1
@@ -1,4 +1,4 @@
-$Script:Teams = [ordered] @{
+﻿$Script:Teams = [ordered] @{
     Name       = 'Microsoft Teams Report'
     Enabled    = $true
     Execute    = {

--- a/Private/Get-GraphEssentialsGroupOwner.ps1
+++ b/Private/Get-GraphEssentialsGroupOwner.ps1
@@ -1,0 +1,41 @@
+function Get-GraphEssentialsGroupOwner {
+    <#
+    .SYNOPSIS
+    Retrieves every owner of a Microsoft 365 group.
+
+    .DESCRIPTION
+    Uses the Microsoft Graph beta owner relationship because the v1.0 relationship can omit
+    service-principal owners during Microsoft's staged rollout. Follows every @odata.nextLink
+    and returns a small, consistent owner projection for users, service principals, and other
+    directory object types.
+
+    .PARAMETER GroupId
+    The Microsoft 365 group identifier. A Team uses the same identifier as its backing group.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $GroupId
+    )
+
+    $EncodedGroupId = [uri]::EscapeDataString($GroupId)
+    $Uri = "/beta/groups/$EncodedGroupId/owners"
+
+    while ($Uri) {
+        $Response = Invoke-MgGraphRequest -Method GET -Uri $Uri -OutputType PSObject -ErrorAction Stop
+        foreach ($Owner in @($Response.value)) {
+            if ($null -eq $Owner) {
+                continue
+            }
+
+            [PSCustomObject] @{
+                DisplayName       = $Owner.displayName
+                Mail              = $Owner.mail
+                UserPrincipalName = $Owner.userPrincipalName
+                Id                = $Owner.id
+                ObjectType        = $Owner.'@odata.type'
+            }
+        }
+
+        $Uri = $Response.'@odata.nextLink'
+    }
+}

--- a/Private/Resolve-GraphEssentialsUserLicenseAssignments.ps1
+++ b/Private/Resolve-GraphEssentialsUserLicenseAssignments.ps1
@@ -1,0 +1,83 @@
+function Resolve-GraphEssentialsUserLicenseAssignments {
+    <#
+    .SYNOPSIS
+    Normalizes Microsoft Graph user license assignments.
+
+    .DESCRIPTION
+    Combines the detailed LicenseAssignmentStates collection with AssignedLicenses. Detailed
+    assignment state is preserved when available, while AssignedLicenses supplies any SKU that
+    is missing from the state collection.
+
+    .PARAMETER User
+    Microsoft Graph user object containing LicenseAssignmentStates and AssignedLicenses.
+
+    .PARAMETER LicenseLookup
+    Dictionary that maps Microsoft Graph SKU identifiers to display names.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $User,
+        [Parameter(Mandatory)][System.Collections.IDictionary] $LicenseLookup
+    )
+
+    $StateSkuIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    foreach ($License in @($User.LicenseAssignmentStates)) {
+        if ($null -eq $License -or $null -eq $License.SkuId) {
+            continue
+        }
+
+        $SkuId = [string] $License.SkuId
+        $null = $StateSkuIds.Add($SkuId)
+        $LicenseName = $LicenseLookup[$License.SkuId]
+        $KnownSku = [bool] $LicenseName
+        if (-not $KnownSku) {
+            $LicenseName = $SkuId
+        }
+
+        if ($License.State -eq 'Active' -and $License.AssignedByGroup) {
+            $Status = 'Group'
+        } elseif ($License.State -eq 'Active') {
+            $Status = 'Direct'
+        } elseif ($License.State) {
+            $Status = [string] $License.State
+        } else {
+            $Status = 'Unknown'
+        }
+
+        [PSCustomObject] @{
+            SkuId       = $SkuId
+            Name        = [string] $LicenseName
+            Status      = $Status
+            Error       = if ($License.Error) { [string] $License.Error } else { $null }
+            KnownSku    = $KnownSku
+            DetailState = $true
+        }
+    }
+
+    foreach ($License in @($User.AssignedLicenses)) {
+        if ($null -eq $License -or $null -eq $License.SkuId) {
+            continue
+        }
+
+        $SkuId = [string] $License.SkuId
+        if ($StateSkuIds.Contains($SkuId)) {
+            continue
+        }
+
+        $LicenseName = $LicenseLookup[$License.SkuId]
+        $KnownSku = [bool] $LicenseName
+        if (-not $KnownSku) {
+            $LicenseName = $SkuId
+        }
+
+        [PSCustomObject] @{
+            SkuId       = $SkuId
+            Name        = [string] $LicenseName
+            Status      = 'Assigned'
+            Error       = $null
+            KnownSku    = $KnownSku
+            DetailState = $false
+        }
+    }
+}

--- a/Public/Get-MyTeam.ps1
+++ b/Public/Get-MyTeam.ps1
@@ -8,7 +8,9 @@ function Get-MyTeam {
     and team settings. Can organize information by team owner and optionally return as a hashtable.
 
     .PARAMETER PerOwner
-    When specified, organizes the output by team owner instead of by team.
+    When specified, organizes the output by team owner instead of by team. Teams with no owner
+    are returned under [No owner], while teams whose owner state could not be read are returned
+    under [Owner state unavailable].
 
     .PARAMETER AsHashtable
     When specified, returns data as a hashtable instead of objects.
@@ -26,7 +28,9 @@ function Get-MyTeam {
     Returns Teams information as a hashtable for easier programmatic access.
 
     .NOTES
-    This function requires the Microsoft.Graph.Teams module and appropriate permissions.
+    This function requires the Microsoft.Graph.Teams and Microsoft.Graph.Groups modules.
+    Reading team settings typically requires TeamSettings.Read.All. Reading owners requires
+    GroupMember.Read.All or another permission that can read Microsoft 365 group owners.
     #>
     [CmdletBinding()]
     param(
@@ -45,12 +49,45 @@ function Get-MyTeam {
     }
 
     foreach ($Team in $Teams) {
+        $TeamDetails = $null
         try {
-            $TeamDetails = Get-MgTeam -TeamId $Team.Id -Property DisplayName, Description, CreatedDateTime, GuestSettings, MemberSettings -ExpandProperty Summary -ErrorAction Stop
-            $Owner = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/v1.0/teams/$($Team.Id)/owners" -ContentType 'application/json; charset=UTF-8' -ErrorAction Stop
+            $TeamDetails = Get-MgTeam -TeamId $Team.Id -Property DisplayName, Description, CreatedDateTime, GuestSettings, MemberSettings, Summary -ErrorAction Stop
         } catch {
-            Write-Warning -Message "Get-MyTeam - Error (extended) on team $($Team.DisplayName) / $($Team.Id): $($_.Exception.Message)"
-            continue
+            Write-Warning -Message "Get-MyTeam - Couldn't get extended details for team $($Team.DisplayName) / $($Team.Id): $($_.Exception.Message)"
+        }
+
+        $Owners = @()
+        $OwnersRetrieved = $false
+        try {
+            $Owners = @(
+                foreach ($Owner in @(Get-MgGroupOwner -GroupId $Team.Id -All -ErrorAction Stop)) {
+                    $AdditionalProperties = $Owner.AdditionalProperties
+                    $DisplayName = $Owner.DisplayName
+                    $Mail = $Owner.Mail
+                    $UserPrincipalName = $Owner.UserPrincipalName
+                    if ($AdditionalProperties) {
+                        if (-not $DisplayName) {
+                            $DisplayName = $AdditionalProperties['displayName']
+                        }
+                        if (-not $Mail) {
+                            $Mail = $AdditionalProperties['mail']
+                        }
+                        if (-not $UserPrincipalName) {
+                            $UserPrincipalName = $AdditionalProperties['userPrincipalName']
+                        }
+                    }
+
+                    [PSCustomObject] @{
+                        DisplayName       = $DisplayName
+                        Mail              = $Mail
+                        UserPrincipalName = $UserPrincipalName
+                        Id                = $Owner.Id
+                    }
+                }
+            )
+            $OwnersRetrieved = $true
+        } catch {
+            Write-Warning -Message "Get-MyTeam - Couldn't get owners for team $($Team.DisplayName) / $($Team.Id): $($_.Exception.Message)"
         }
 
         if ($TeamDetails.CreatedDateTime) {
@@ -59,10 +96,42 @@ function Get-MyTeam {
             $CreatedDaysAgo = $null
         }
 
-        $HasOwners = $Owner.value.Count -gt 0
-        $HasMultipleOwners = $Owner.value.Count -gt 1
-        $HasGuests = $TeamDetails.Summary.GuestsCount -gt 0
-        $GuestControlsEnabled = $TeamDetails.GuestSettings.AllowCreateUpdateChannels -or $TeamDetails.GuestSettings.AllowDeleteChannels
+        if ($OwnersRetrieved) {
+            $OwnerCount = $Owners.Count
+            $HasOwners = $OwnerCount -gt 0
+            $HasMultipleOwners = $OwnerCount -gt 1
+        } else {
+            $OwnerCount = $null
+            $HasOwners = $null
+            $HasMultipleOwners = $null
+        }
+        if ($null -ne $TeamDetails -and $null -ne $TeamDetails.Summary -and $null -ne $TeamDetails.Summary.GuestsCount) {
+            $HasGuests = $TeamDetails.Summary.GuestsCount -gt 0
+        } else {
+            $HasGuests = $null
+        }
+        if ($null -ne $TeamDetails -and $null -ne $TeamDetails.GuestSettings) {
+            $GuestAllowCreateUpdateChannels = $TeamDetails.GuestSettings.AllowCreateUpdateChannels
+            $GuestAllowDeleteChannels = $TeamDetails.GuestSettings.AllowDeleteChannels
+            if ($GuestAllowCreateUpdateChannels -eq $true -or $GuestAllowDeleteChannels -eq $true) {
+                $GuestControlsEnabled = $true
+            } elseif ($null -ne $GuestAllowCreateUpdateChannels -and $null -ne $GuestAllowDeleteChannels) {
+                $GuestControlsEnabled = $false
+            } else {
+                $GuestControlsEnabled = $null
+            }
+        } else {
+            $GuestAllowCreateUpdateChannels = $null
+            $GuestAllowDeleteChannels = $null
+            $GuestControlsEnabled = $null
+        }
+        if ($null -ne $Team.Visibility) {
+            $IsPublic = $Team.Visibility -eq 'Public'
+            $IsPrivate = $Team.Visibility -eq 'Private'
+        } else {
+            $IsPublic = $null
+            $IsPrivate = $null
+        }
 
         $TeamInformation = [ordered] @{
             Id                                = $Team.Id
@@ -70,21 +139,21 @@ function Get-MyTeam {
             CreatedDaysAgo                    = $CreatedDaysAgo
             Team                              = $Team.DisplayName
             Visibility                        = $Team.Visibility
-            IsPublic                          = $Team.Visibility -eq 'Public'
-            IsPrivate                         = $Team.Visibility -eq 'Private'
-            OwnerCount                        = $Owner.value.Count
+            IsPublic                          = $IsPublic
+            IsPrivate                         = $IsPrivate
+            OwnerCount                        = $OwnerCount
             HasOwners                         = $HasOwners
             HasMultipleOwners                 = $HasMultipleOwners
             MembersCount                      = $TeamDetails.Summary.MembersCount
             GuestsCount                       = $TeamDetails.Summary.GuestsCount
             HasGuests                         = $HasGuests
             Description                       = $Team.Description
-            OwnerDisplayName                  = $Owner.value.DisplayName
-            OwnerMail                         = $Owner.value.Mail
-            OwnerUserPrincipalName            = $Owner.value.UserPrincipalName
-            OwnerId                           = $Owner.value.Id
-            GuestAllowCreateUpdateChannels    = $TeamDetails.GuestSettings.AllowCreateUpdateChannels
-            GuestAllowDeleteChannels          = $TeamDetails.GuestSettings.AllowDeleteChannels
+            OwnerDisplayName                  = $Owners.DisplayName
+            OwnerMail                         = $Owners.Mail
+            OwnerUserPrincipalName            = $Owners.UserPrincipalName
+            OwnerId                           = $Owners.Id
+            GuestAllowCreateUpdateChannels    = $GuestAllowCreateUpdateChannels
+            GuestAllowDeleteChannels          = $GuestAllowDeleteChannels
             GuestControlsEnabled              = $GuestControlsEnabled
             AllowAddRemoveApps                = $TeamDetails.MemberSettings.AllowAddRemoveApps
             AllowCreatePrivateChannels        = $TeamDetails.MemberSettings.AllowCreatePrivateChannels
@@ -95,14 +164,37 @@ function Get-MyTeam {
         }
 
         if ($PerOwner) {
-            foreach ($O in $Owner.value) {
-                if (-not $OwnerShip[$O.UserPrincipalName]) {
-                    $OwnerShip[$O.UserPrincipalName] = [System.Collections.Generic.List[PSCustomObject]]::new()
+            foreach ($Owner in $Owners) {
+                $OwnerKey = $Owner.UserPrincipalName
+                if (-not $OwnerKey) {
+                    $OwnerKey = $Owner.Mail
+                }
+                if (-not $OwnerKey) {
+                    $OwnerKey = $Owner.Id
+                }
+                if (-not $OwnerKey) {
+                    Write-Warning -Message "Get-MyTeam - Owner without a usable identity on team $($Team.DisplayName) / $($Team.Id) was skipped."
+                    continue
+                }
+
+                if (-not $OwnerShip[$OwnerKey]) {
+                    $OwnerShip[$OwnerKey] = [System.Collections.Generic.List[PSCustomObject]]::new()
                 }
                 if ($AsHashtable) {
-                    $OwnerShip[$O.UserPrincipalName].Add($TeamInformation)
+                    $OwnerShip[$OwnerKey].Add($TeamInformation)
                 } else {
-                    $OwnerShip[$O.UserPrincipalName].Add([PSCustomObject] $TeamInformation)
+                    $OwnerShip[$OwnerKey].Add([PSCustomObject] $TeamInformation)
+                }
+            }
+            if ($Owners.Count -eq 0) {
+                $OwnerKey = if ($OwnersRetrieved) { '[No owner]' } else { '[Owner state unavailable]' }
+                if (-not $OwnerShip[$OwnerKey]) {
+                    $OwnerShip[$OwnerKey] = [System.Collections.Generic.List[PSCustomObject]]::new()
+                }
+                if ($AsHashtable) {
+                    $OwnerShip[$OwnerKey].Add($TeamInformation)
+                } else {
+                    $OwnerShip[$OwnerKey].Add([PSCustomObject] $TeamInformation)
                 }
             }
         } else {

--- a/Public/Get-MyTeam.ps1
+++ b/Public/Get-MyTeam.ps1
@@ -28,7 +28,7 @@ function Get-MyTeam {
     Returns Teams information as a hashtable for easier programmatic access.
 
     .NOTES
-    This function requires the Microsoft.Graph.Teams and Microsoft.Graph.Groups modules.
+    This function requires the Microsoft.Graph.Teams and Microsoft.Graph.Authentication modules.
     Reading team settings typically requires TeamSettings.Read.All. Reading owners requires
     GroupMember.Read.All or another permission that can read Microsoft 365 group owners.
     #>
@@ -59,32 +59,7 @@ function Get-MyTeam {
         $Owners = @()
         $OwnersRetrieved = $false
         try {
-            $Owners = @(
-                foreach ($Owner in @(Get-MgGroupOwner -GroupId $Team.Id -All -ErrorAction Stop)) {
-                    $AdditionalProperties = $Owner.AdditionalProperties
-                    $DisplayName = $Owner.DisplayName
-                    $Mail = $Owner.Mail
-                    $UserPrincipalName = $Owner.UserPrincipalName
-                    if ($AdditionalProperties) {
-                        if (-not $DisplayName) {
-                            $DisplayName = $AdditionalProperties['displayName']
-                        }
-                        if (-not $Mail) {
-                            $Mail = $AdditionalProperties['mail']
-                        }
-                        if (-not $UserPrincipalName) {
-                            $UserPrincipalName = $AdditionalProperties['userPrincipalName']
-                        }
-                    }
-
-                    [PSCustomObject] @{
-                        DisplayName       = $DisplayName
-                        Mail              = $Mail
-                        UserPrincipalName = $UserPrincipalName
-                        Id                = $Owner.Id
-                    }
-                }
-            )
+            $Owners = @(Get-GraphEssentialsGroupOwner -GroupId $Team.Id -ErrorAction Stop)
             $OwnersRetrieved = $true
         } catch {
             Write-Warning -Message "Get-MyTeam - Couldn't get owners for team $($Team.DisplayName) / $($Team.Id): $($_.Exception.Message)"
@@ -152,6 +127,7 @@ function Get-MyTeam {
             OwnerMail                         = $Owners.Mail
             OwnerUserPrincipalName            = $Owners.UserPrincipalName
             OwnerId                           = $Owners.Id
+            OwnerObjectType                   = $Owners.ObjectType
             GuestAllowCreateUpdateChannels    = $GuestAllowCreateUpdateChannels
             GuestAllowDeleteChannels          = $GuestAllowDeleteChannels
             GuestControlsEnabled              = $GuestControlsEnabled

--- a/Public/Get-MyUser.ps1
+++ b/Public/Get-MyUser.ps1
@@ -166,6 +166,7 @@ function Get-MyUser {
             NeverSuccessfullySignedIn        = $NeverSuccessfullySignedIn
             SignInPattern                    = $SignInPattern
         }
+        $ResolvedLicenses = @(Resolve-GraphEssentialsUserLicenseAssignments -User $User -LicenseLookup $AllLicenses['Licenses'])
 
         if ($PerLicense) {
             $LicensesErrors = [System.Collections.Generic.List[string]]::new()
@@ -174,21 +175,12 @@ function Get-MyUser {
                 $OutputUser[$License] = [System.Collections.Generic.List[string]]::new()
             }
 
-            foreach ($License in $User.LicenseAssignmentStates) {
+            foreach ($License in $ResolvedLicenses) {
                 try {
-                    $LicenseFound = $AllLicenses['Licenses'][$License.SkuId]
-                    if ($LicenseFound) {
-                        if ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -gt 0) {
-                            $OutputUser[$LicenseFound].Add('Group')
-                        } elseif ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -eq 0) {
-                            $OutputUser[$LicenseFound].Add('Direct')
-                        }
+                    if ($License.KnownSku) {
+                        $OutputUser[$License.Name].Add($License.Status)
                     } else {
-                        if ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -gt 0) {
-                            $OutputUser['DifferentLicense'].Add("Group $($License.SkuId)")
-                        } elseif ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -eq 0) {
-                            $OutputUser['DifferentLicense'].Add("Direct $($License.SkuId)")
-                        }
+                        $OutputUser['DifferentLicense'].Add("$($License.Status) $($License.SkuId)")
                         Write-Warning -Message "$($License.SkuId) not found in AllLicenses"
                         $LicensesErrors.Add("License ID $($License.SkuId) not found in All Licenses")
                     }
@@ -217,30 +209,22 @@ function Get-MyUser {
             $LicensesList = [System.Collections.Generic.List[string]]::new()
             $LicensesStatus = [System.Collections.Generic.List[string]]::new()
             $LicensesErrors = [System.Collections.Generic.List[string]]::new()
-            foreach ($License in $User.LicenseAssignmentStates) {
-                $LicenseFound = $AllLicenses['Licenses'][$License.SkuId]
-                if ($LicenseFound -and $LicensesList -notcontains $LicenseFound) {
-                    $LicensesList.Add($LicenseFound)
-                    if ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -gt 0) {
-                        $LicensesStatus.Add('Group')
-                    } elseif ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -eq 0) {
-                        $LicensesStatus.Add('Direct')
-                    } else {
-                        $LicensesStatus.Add($License.State)
-                        if ($License.Error -and $LicensesErrors -notcontains $License.Error) {
-                            $LicensesErrors.Add($License.Error)
-                        }
+            foreach ($License in $ResolvedLicenses) {
+                if ($LicensesList -notcontains $License.Name) {
+                    $LicensesList.Add($License.Name)
+                }
+                if ($LicensesStatus -notcontains $License.Status) {
+                    $LicensesStatus.Add($License.Status)
+                }
+                if ($License.Error -and $LicensesErrors -notcontains $License.Error) {
+                    $LicensesErrors.Add($License.Error)
+                }
+                if (-not $License.KnownSku) {
+                    $MissingLicenseError = "License ID $($License.SkuId) not found in All Licenses"
+                    if ($LicensesErrors -notcontains $MissingLicenseError) {
+                        $LicensesErrors.Add($MissingLicenseError)
                     }
-                } elseif (-not $LicenseFound) {
-                    if ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -gt 0) {
-                        $LicensesStatus.Add('Group')
-                    } elseif ($License.State -eq 'Active' -and $License.AssignedByGroup.Count -eq 0) {
-                        $LicensesStatus.Add('Direct')
-                    }
-                    $LicensesErrors.Add("License ID $($License.SkuId) not found in All Licenses")
                     Write-Warning -Message "Get-MyUser - License ID $($License.SkuId) not found in AllLicenses for $($User.DisplayName)"
-                } else {
-                    $LicensesStatus.Add('Duplicate')
                 }
             }
 

--- a/Tests/Get-MyTeam.Tests.ps1
+++ b/Tests/Get-MyTeam.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsGroupOwner.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyTeam.ps1')
 
     function Get-MgTeam {
@@ -11,13 +12,10 @@ BeforeAll {
         )
     }
 
-    function Get-MgGroupOwner {
-        param(
-            [string] $GroupId,
-            [switch] $All,
-            $ErrorAction
-        )
+    function Invoke-MgGraphRequest {
+        param([string] $Method, [string] $Uri, [string] $OutputType, $ErrorAction)
     }
+
 }
 
 Describe 'Get-MyTeam' {
@@ -59,12 +57,13 @@ Describe 'Get-MyTeam' {
             }
         }
 
-        Mock Get-MgGroupOwner {
+        Mock Get-GraphEssentialsGroupOwner {
             [PSCustomObject] @{
                 DisplayName       = 'Team Owner'
                 Mail              = 'owner@contoso.com'
                 UserPrincipalName = 'owner@contoso.com'
                 Id                = 'owner-1'
+                ObjectType        = '#microsoft.graph.user'
             }
         }
     }
@@ -74,14 +73,15 @@ Describe 'Get-MyTeam' {
 
         $script:TeamDetailsParameters.Property | Should -Contain 'Summary'
         $script:TeamDetailsParameters.ExpandProperty | Should -BeNullOrEmpty
-        Should -Invoke Get-MgGroupOwner -Times 1 -Exactly -ParameterFilter {
-            $GroupId -eq 'team-1' -and $All
+        Should -Invoke Get-GraphEssentialsGroupOwner -Times 1 -Exactly -ParameterFilter {
+            $GroupId -eq 'team-1'
         }
         $result.MembersCount | Should -Be 8
         $result.GuestsCount | Should -Be 2
         $result.HasGuests | Should -BeTrue
         $result.OwnerCount | Should -Be 1
         $result.OwnerUserPrincipalName | Should -Be 'owner@contoso.com'
+        $result.OwnerObjectType | Should -Be '#microsoft.graph.user'
     }
 
     It 'keeps the team when extended team details fail' {
@@ -107,7 +107,7 @@ Describe 'Get-MyTeam' {
     }
 
     It 'keeps the team and reports owner state as unknown when owner retrieval fails' {
-        Mock Get-MgGroupOwner { throw 'owners unavailable' }
+        Mock Get-GraphEssentialsGroupOwner { throw 'owners unavailable' }
 
         $result = Get-MyTeam -WarningAction SilentlyContinue
 
@@ -117,14 +117,12 @@ Describe 'Get-MyTeam' {
         $result.MembersCount | Should -Be 8
     }
 
-    It 'counts non-user group owners returned through the uncast owner relationship' {
-        Mock Get-MgGroupOwner {
+    It 'counts non-user group owners returned through the beta owner projection' {
+        Mock Get-GraphEssentialsGroupOwner {
             [PSCustomObject] @{
-                AdditionalProperties = @{
-                    '@odata.type' = '#microsoft.graph.servicePrincipal'
-                    displayName   = 'Automation owner'
-                }
-                Id                   = 'service-principal-1'
+                DisplayName = 'Automation owner'
+                Id          = 'service-principal-1'
+                ObjectType  = '#microsoft.graph.servicePrincipal'
             }
         }
 
@@ -134,10 +132,11 @@ Describe 'Get-MyTeam' {
         $result.HasOwners | Should -BeTrue
         $result.OwnerDisplayName | Should -Be 'Automation owner'
         $result.OwnerId | Should -Be 'service-principal-1'
+        $result.OwnerObjectType | Should -Be '#microsoft.graph.servicePrincipal'
     }
 
     It 'keeps a team in the unavailable-owner bucket when per-owner retrieval fails' {
-        Mock Get-MgGroupOwner { throw 'owners unavailable' }
+        Mock Get-GraphEssentialsGroupOwner { throw 'owners unavailable' }
 
         $result = Get-MyTeam -PerOwner -WarningAction SilentlyContinue
 
@@ -147,7 +146,7 @@ Describe 'Get-MyTeam' {
     }
 
     It 'keeps a genuinely ownerless team in a distinct per-owner bucket' {
-        Mock Get-MgGroupOwner { @() }
+        Mock Get-GraphEssentialsGroupOwner { @() }
 
         $result = Get-MyTeam -PerOwner
 
@@ -189,6 +188,50 @@ Describe 'Get-MyTeam' {
         $result.Keys | Should -Contain 'owner@contoso.com'
         $result['owner@contoso.com'].Count | Should -Be 1
         $result['owner@contoso.com'][0].Team | Should -Be 'Operations'
+    }
+}
+
+Describe 'Get-GraphEssentialsGroupOwner' {
+    BeforeEach {
+        $script:OwnerRequest = 0
+        Mock Invoke-MgGraphRequest {
+            $script:OwnerRequest++
+            if ($script:OwnerRequest -eq 1) {
+                [PSCustomObject] @{
+                    value             = @([PSCustomObject] @{
+                            '@odata.type'     = '#microsoft.graph.user'
+                            displayName       = 'Team Owner'
+                            id                = 'owner-1'
+                            mail              = 'owner@contoso.com'
+                            userPrincipalName = 'owner@contoso.com'
+                        })
+                    '@odata.nextLink' = 'https://graph.microsoft.com/beta/groups/team-1/owners?$skiptoken=next'
+                }
+            } else {
+                [PSCustomObject] @{
+                    value = @([PSCustomObject] @{
+                            '@odata.type' = '#microsoft.graph.servicePrincipal'
+                            displayName   = 'Automation owner'
+                            id            = 'service-principal-1'
+                        })
+                }
+            }
+        }
+    }
+
+    It 'pages the beta relationship and retains user and service-principal owners' {
+        $result = @(Get-GraphEssentialsGroupOwner -GroupId 'team-1')
+
+        Should -Invoke Invoke-MgGraphRequest -Times 2 -Exactly
+        Should -Invoke Invoke-MgGraphRequest -Times 1 -Exactly -ParameterFilter {
+            $Method -eq 'GET' -and
+            $Uri -eq '/beta/groups/team-1/owners' -and
+            $OutputType -eq 'PSObject'
+        }
+        $result.Count | Should -Be 2
+        $result[0].UserPrincipalName | Should -Be 'owner@contoso.com'
+        $result[1].ObjectType | Should -Be '#microsoft.graph.servicePrincipal'
+        $result[1].Id | Should -Be 'service-principal-1'
     }
 }
 

--- a/Tests/Get-MyTeam.Tests.ps1
+++ b/Tests/Get-MyTeam.Tests.ps1
@@ -1,0 +1,238 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Public\Get-MyTeam.ps1')
+
+    function Get-MgTeam {
+        param(
+            [switch] $All,
+            [string] $TeamId,
+            [string[]] $Property,
+            [string[]] $ExpandProperty,
+            $ErrorAction
+        )
+    }
+
+    function Get-MgGroupOwner {
+        param(
+            [string] $GroupId,
+            [switch] $All,
+            $ErrorAction
+        )
+    }
+}
+
+Describe 'Get-MyTeam' {
+    BeforeEach {
+        $script:TeamDetailsParameters = $null
+
+        Mock Get-MgTeam {
+            if ($All) {
+                [PSCustomObject] @{
+                    Id          = 'team-1'
+                    DisplayName = 'Operations'
+                    Description = 'Operations team'
+                    Visibility  = 'Private'
+                }
+            } else {
+                $script:TeamDetailsParameters = [PSCustomObject] @{
+                    Property       = @($Property)
+                    ExpandProperty = @($ExpandProperty)
+                }
+                [PSCustomObject] @{
+                    CreatedDateTime = (Get-Date).AddDays(-5)
+                    GuestSettings   = [PSCustomObject] @{
+                        AllowCreateUpdateChannels = $false
+                        AllowDeleteChannels       = $false
+                    }
+                    MemberSettings  = [PSCustomObject] @{
+                        AllowAddRemoveApps                = $true
+                        AllowCreatePrivateChannels        = $true
+                        AllowCreateUpdateChannels         = $true
+                        AllowCreateUpdateRemoveConnectors = $true
+                        AllowCreateUpdateRemoveTabs       = $true
+                        AllowDeleteChannels               = $true
+                    }
+                    Summary         = [PSCustomObject] @{
+                        MembersCount = 8
+                        GuestsCount  = 2
+                    }
+                }
+            }
+        }
+
+        Mock Get-MgGroupOwner {
+            [PSCustomObject] @{
+                DisplayName       = 'Team Owner'
+                Mail              = 'owner@contoso.com'
+                UserPrincipalName = 'owner@contoso.com'
+                Id                = 'owner-1'
+            }
+        }
+    }
+
+    It 'requests team summary and automatically pages owners through the group relationship' {
+        $result = Get-MyTeam
+
+        $script:TeamDetailsParameters.Property | Should -Contain 'Summary'
+        $script:TeamDetailsParameters.ExpandProperty | Should -BeNullOrEmpty
+        Should -Invoke Get-MgGroupOwner -Times 1 -Exactly -ParameterFilter {
+            $GroupId -eq 'team-1' -and $All
+        }
+        $result.MembersCount | Should -Be 8
+        $result.GuestsCount | Should -Be 2
+        $result.HasGuests | Should -BeTrue
+        $result.OwnerCount | Should -Be 1
+        $result.OwnerUserPrincipalName | Should -Be 'owner@contoso.com'
+    }
+
+    It 'keeps the team when extended team details fail' {
+        Mock Get-MgTeam {
+            if ($All) {
+                [PSCustomObject] @{
+                    Id          = 'team-1'
+                    DisplayName = 'Operations'
+                    Description = 'Operations team'
+                    Visibility  = 'Private'
+                }
+            } else {
+                throw 'details unavailable'
+            }
+        }
+
+        $result = Get-MyTeam -WarningAction SilentlyContinue
+
+        $result.Team | Should -Be 'Operations'
+        $result.OwnerCount | Should -Be 1
+        $result.MembersCount | Should -BeNullOrEmpty
+        $result.HasGuests | Should -BeNullOrEmpty
+    }
+
+    It 'keeps the team and reports owner state as unknown when owner retrieval fails' {
+        Mock Get-MgGroupOwner { throw 'owners unavailable' }
+
+        $result = Get-MyTeam -WarningAction SilentlyContinue
+
+        $result.Team | Should -Be 'Operations'
+        $result.OwnerCount | Should -BeNullOrEmpty
+        $result.HasOwners | Should -BeNullOrEmpty
+        $result.MembersCount | Should -Be 8
+    }
+
+    It 'counts non-user group owners returned through the uncast owner relationship' {
+        Mock Get-MgGroupOwner {
+            [PSCustomObject] @{
+                AdditionalProperties = @{
+                    '@odata.type' = '#microsoft.graph.servicePrincipal'
+                    displayName   = 'Automation owner'
+                }
+                Id                   = 'service-principal-1'
+            }
+        }
+
+        $result = Get-MyTeam
+
+        $result.OwnerCount | Should -Be 1
+        $result.HasOwners | Should -BeTrue
+        $result.OwnerDisplayName | Should -Be 'Automation owner'
+        $result.OwnerId | Should -Be 'service-principal-1'
+    }
+
+    It 'keeps a team in the unavailable-owner bucket when per-owner retrieval fails' {
+        Mock Get-MgGroupOwner { throw 'owners unavailable' }
+
+        $result = Get-MyTeam -PerOwner -WarningAction SilentlyContinue
+
+        $result.Keys | Should -Contain '[Owner state unavailable]'
+        $result['[Owner state unavailable]'][0].Team | Should -Be 'Operations'
+        $result['[Owner state unavailable]'][0].HasOwners | Should -BeNullOrEmpty
+    }
+
+    It 'keeps a genuinely ownerless team in a distinct per-owner bucket' {
+        Mock Get-MgGroupOwner { @() }
+
+        $result = Get-MyTeam -PerOwner
+
+        $result.Keys | Should -Contain '[No owner]'
+        $result['[No owner]'][0].HasOwners | Should -BeFalse
+    }
+
+    It 'does not coerce missing visibility and guest fields to false' {
+        Mock Get-MgTeam {
+            if ($All) {
+                [PSCustomObject] @{
+                    Id          = 'team-1'
+                    DisplayName = 'Operations'
+                    Description = 'Operations team'
+                    Visibility  = $null
+                }
+            } else {
+                [PSCustomObject] @{
+                    GuestSettings = [PSCustomObject] @{
+                        AllowCreateUpdateChannels = $null
+                        AllowDeleteChannels       = $false
+                    }
+                    Summary       = [PSCustomObject] @{ GuestsCount = $null }
+                }
+            }
+        }
+
+        $result = Get-MyTeam
+
+        $result.IsPublic | Should -BeNullOrEmpty
+        $result.IsPrivate | Should -BeNullOrEmpty
+        $result.HasGuests | Should -BeNullOrEmpty
+        $result.GuestControlsEnabled | Should -BeNullOrEmpty
+    }
+
+    It 'organizes teams by the owner user principal name' {
+        $result = Get-MyTeam -PerOwner
+
+        $result.Keys | Should -Contain 'owner@contoso.com'
+        $result['owner@contoso.com'].Count | Should -Be 1
+        $result['owner@contoso.com'][0].Team | Should -Be 'Operations'
+    }
+}
+
+Describe 'Teams report unknown-state summary' {
+    BeforeAll {
+        . (Join-Path $PSScriptRoot '..\Private\Configuration.Teams.ps1')
+    }
+
+    It 'separates unavailable owner and guest state from explicit false values' {
+        $Script:Reporting = @{
+            Teams = @{
+                Data = @(
+                    [PSCustomObject] @{
+                        HasGuests              = $false
+                        HasOwners              = $false
+                        HasMultipleOwners      = $false
+                        OwnerCount             = 0
+                        Visibility             = 'Private'
+                        IsPrivate              = $true
+                        IsPublic               = $false
+                        OwnerUserPrincipalName = $null
+                    }
+                    [PSCustomObject] @{
+                        HasGuests              = $null
+                        HasOwners              = $null
+                        HasMultipleOwners      = $null
+                        OwnerCount             = $null
+                        Visibility             = $null
+                        IsPrivate              = $null
+                        IsPublic               = $null
+                        OwnerUserPrincipalName = $null
+                    }
+                )
+            }
+        }
+
+        $result = & $Script:Teams.Summary
+
+        $result.Overview[0].OwnerlessTeams | Should -Be 1
+        $result.Overview[0].OwnerStateUnavailable | Should -Be 1
+        $result.Overview[0].TeamsWithoutGuests | Should -Be 1
+        $result.Overview[0].GuestStateUnavailable | Should -Be 1
+        @($result.OwnerlessTeams).Count | Should -Be 1
+        @($result.ReviewCandidates | Where-Object ReviewFlags -eq 'No owners').Count | Should -Be 1
+        @($result.ReviewCandidates | Where-Object ReviewFlags -eq 'Owner state unavailable').Count | Should -Be 1
+    }
+}

--- a/Tests/Get-MyUser.Tests.ps1
+++ b/Tests/Get-MyUser.Tests.ps1
@@ -1,0 +1,115 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Resolve-GraphEssentialsUserLicenseAssignments.ps1')
+    . (Join-Path $PSScriptRoot '..\Public\Get-MyUser.ps1')
+
+    function Get-MyLicense {
+        param([switch] $Internal)
+    }
+
+    function Get-MgUser {
+        param(
+            [switch] $All,
+            [string[]] $Property,
+            [string[]] $ExpandProperty
+        )
+    }
+
+    function Stop-TimeLog {
+        param($Time, $Option)
+        '0 seconds'
+    }
+}
+
+Describe 'Get-MyUser license projection' {
+    BeforeEach {
+        $script:SkuId = [Guid] '11111111-1111-1111-1111-111111111111'
+        $script:LicenseLookup = [ordered] @{}
+        $script:LicenseLookup[$script:SkuId] = 'Microsoft 365 E3'
+
+        Mock Get-MyLicense {
+            [ordered] @{
+                Licenses     = $script:LicenseLookup
+                ServicePlans = [ordered] @{}
+            }
+        }
+
+        Mock Get-MgUser {
+            [PSCustomObject] @{
+                AccountEnabled                  = $true
+                AssignedLicenses                = @([PSCustomObject] @{ SkuId = $script:SkuId })
+                AssignedPlans                   = @()
+                CreatedDateTime                 = $null
+                DisplayName                     = 'Licensed User'
+                GivenName                       = 'Licensed'
+                Id                              = 'user-1'
+                JobTitle                        = $null
+                LastPasswordChangeDateTime      = $null
+                LicenseAssignmentStates         = @()
+                Mail                            = 'licensed@contoso.com'
+                Manager                         = $null
+                OnPremisesDistinguishedName     = $null
+                OnPremisesLastSyncDateTime      = $null
+                OnPremisesSyncEnabled           = $null
+                SignInActivity                  = $null
+                SurName                         = 'User'
+                UserPrincipalName               = 'licensed@contoso.com'
+                UserType                        = 'Member'
+            }
+        }
+    }
+
+    It 'falls back to AssignedLicenses when detailed assignment state is empty' {
+        $result = Get-MyUser
+
+        $result.HasLicenses | Should -BeTrue
+        $result.LicenseCount | Should -Be 1
+        $result.Licenses | Should -Contain 'Microsoft 365 E3'
+        $result.LicensesStatus | Should -Contain 'Assigned'
+    }
+
+    It 'uses detailed assignment state without duplicating the AssignedLicenses entry' {
+        Mock Get-MgUser {
+            [PSCustomObject] @{
+                AccountEnabled                  = $true
+                AssignedLicenses                = @([PSCustomObject] @{ SkuId = $script:SkuId })
+                AssignedPlans                   = @()
+                DisplayName                     = 'Licensed User'
+                Id                              = 'user-1'
+                LicenseAssignmentStates         = @([PSCustomObject] @{
+                        AssignedByGroup = $null
+                        Error           = $null
+                        SkuId           = $script:SkuId
+                        State           = 'Active'
+                    })
+                Mail                            = 'licensed@contoso.com'
+                Manager                         = $null
+                OnPremisesSyncEnabled           = $null
+                SignInActivity                  = $null
+                UserPrincipalName               = 'licensed@contoso.com'
+                UserType                        = 'Member'
+            }
+        }
+
+        $result = Get-MyUser
+
+        $result.LicenseCount | Should -Be 1
+        $result.LicensesStatus | Should -Contain 'Direct'
+        $result.LicensesStatus | Should -Not -Contain 'Assigned'
+    }
+
+    It 'keeps an assigned SKU visible when the tenant SKU lookup lacks its display name' {
+        $script:LicenseLookup.Clear()
+
+        $result = Get-MyUser -WarningAction SilentlyContinue
+
+        $result.HasLicenses | Should -BeTrue
+        $result.Licenses | Should -Contain ([string] $script:SkuId)
+        $result.LicensesErrors | Should -Contain "License ID $($script:SkuId) not found in All Licenses"
+    }
+
+    It 'uses AssignedLicenses fallback in the per-license projection' {
+        $result = Get-MyUser -PerLicense
+
+        $result.'Microsoft 365 E3' | Should -Contain 'Assigned'
+    }
+}


### PR DESCRIPTION
## What changed

- Read Teams owners through a paged Microsoft Graph beta group-owner relationship so service-principal owners are not silently omitted while the v1.0 rollout remains incomplete.
- Preserve Teams when details or owner retrieval is unavailable, including distinct ownerless and unavailable-owner states in `-PerOwner` and the Teams report.
- Include each owner's directory object type and avoid coercing partial visibility, guest, or owner data to `false`.
- Reconcile `LicenseAssignmentStates` with `AssignedLicenses` so assigned and historical or unknown SKUs remain visible rather than producing an empty Licenses column.
- Keep raw source compatible with Windows PowerShell 5.1 by preserving UTF-8 encoding for the Teams report definition.
- Prepare GraphEssentials `0.0.59`.

## Compatibility note

Microsoft documents that the v1.0 group-owner relationship may omit service-principal owners during its staged rollout. This change uses the beta relationship only for owner enumeration. If that request fails, the Team remains in the result with owner state marked unavailable; it is never reported as ownerless.

## Validation

- Full Pester suite: 44/44 passed on PowerShell 7 and Windows PowerShell 5.1, including the CI Pester 5.9.0 version.
- Verified the owner request surface with Microsoft.Graph.Authentication 2.25.0 in both runtimes.
- Live read-only validation against `evotec.pl`: 7 Teams, 7/7 beta owner queries successful, 41 users processed, and all 5 licensed users returned a populated Licenses list.
- Independent local review found four unknown-state/owner-type issues; all were fixed and targeted confirmation was clean. Repository review then found the v1.0 service-principal gap, now covered by paging and mixed user/service-principal tests.

## Release note

LegacyReporting ingests GraphEssentials functions during its build. After GraphEssentials `0.0.59` is published, LegacyReporting must update its minimum version and rebuild before these fixes reach its packaged report.