### PR TITLE
Make user sign-in activity explicitly opt-in

### DIFF
--- a/Examples/ShowMultipleThings.ps1
+++ b/Examples/ShowMultipleThings.ps1
@@ -8,9 +8,10 @@ Get-MyDeviceIntune | Format-Table Name, LastSeen, LastSeenDays, DetailedInventor
 
 Get-MyDeviceIntune -IncludeDetailedInventory | Format-Table Name, DetailedInventoryLoaded, ActivationLockBypassCode, EthernetMacAddress, Iccid, Notes, PhysicalMemoryInBytes, Udid
 
-Get-MyUser | Format-Table DisplayName, UserType, Enabled, LastSignInDateTime, NeverSignedIn, HasLicenses, HasManager
+# Sign-in activity is opt-in and requires AuditLog.Read.All.
+Get-MyUser -IncludeSignInActivity | Format-Table DisplayName, UserType, Enabled, LastSignInDateTime, NeverSignedIn, HasLicenses, HasManager
 
-Get-MyGuest | Format-Table DisplayName, GuestDomain, Enabled, ExternalUserState, LastSignInDateTime, NeverSignedIn, HasRoles, HasLicenses
+Get-MyGuest -IncludeSignInActivity | Format-Table DisplayName, GuestDomain, Enabled, ExternalUserState, LastSignInDateTime, NeverSignedIn, HasRoles, HasLicenses
 
 Get-MyLicense | Format-Table Name, LicensesUsedPercent, LicensesUsedCount, LicenseCountEnabled, UtilizationBand
 

--- a/Private/Configuration.Guests.ps1
+++ b/Private/Configuration.Guests.ps1
@@ -1,8 +1,8 @@
-$Script:Guests = [ordered] @{
+﻿$Script:Guests = [ordered] @{
     Name       = 'Azure Active Directory Guests and External Users'
     Enabled    = $true
     Execute    = {
-        Get-MyGuest
+        Get-MyGuest -IncludeSignInActivity
     }
     Processing = {
 

--- a/Private/Configuration.Users.ps1
+++ b/Private/Configuration.Users.ps1
@@ -1,8 +1,8 @@
-$Script:Users = [ordered] @{
+﻿$Script:Users = [ordered] @{
     Name       = 'Azure Active Directory Users'
     Enabled    = $true
     Execute    = {
-        Get-MyUser
+        Get-MyUser -IncludeSignInActivity
     }
     Processing = {
 

--- a/Private/Configuration.UsersPerLicense.ps1
+++ b/Private/Configuration.UsersPerLicense.ps1
@@ -1,8 +1,8 @@
-$Script:UsersPerLicense = [ordered] @{
+﻿$Script:UsersPerLicense = [ordered] @{
     Name       = 'Azure Active Directory Users Per License'
     Enabled    = $true
     Execute    = {
-        Get-MyUser -PerLicense
+        Get-MyUser -PerLicense -IncludeSignInActivity
     }
     Processing = {
 
@@ -32,7 +32,10 @@ $Script:UsersPerLicense = [ordered] @{
             'ManagerUserPrincipalName', 'ManagerIsSynchronized', 'HasManager', 'LastPasswordChangeDateTime',
             'LastPasswordChangeDays', 'IsSynchronized', 'LastSynchronized', 'LastSynchronizedDays',
             'OnPremisesDistinguishedName', 'LastSignInDateTime', 'LastSignInDaysAgo',
-            'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo', 'NeverSignedIn',
+            'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo',
+            'LastSuccessfulSignInDateTime', 'LastSuccessfulSignInDaysAgo', 'NeverSignedIn',
+            'NeverSuccessfullySignedIn', 'SignInPattern',
+            'SignInActivityRequested', 'SignInActivityAvailable',
             'DifferentLicense', 'LicensesErrors'
         )
 
@@ -274,7 +277,10 @@ $Script:UsersPerLicense = [ordered] @{
                 'ManagerUserPrincipalName', 'ManagerIsSynchronized', 'HasManager', 'LastPasswordChangeDateTime',
                 'LastPasswordChangeDays', 'IsSynchronized', 'LastSynchronized', 'LastSynchronizedDays',
                 'OnPremisesDistinguishedName', 'LastSignInDateTime', 'LastSignInDaysAgo',
-                'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo', 'NeverSignedIn',
+                'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo',
+                'LastSuccessfulSignInDateTime', 'LastSuccessfulSignInDaysAgo', 'NeverSignedIn',
+                'NeverSuccessfullySignedIn', 'SignInPattern',
+                'SignInActivityRequested', 'SignInActivityAvailable',
                 'DifferentLicense', 'LicensesErrors'
             )
 

--- a/Private/Configuration.UsersPerServicePlan.ps1
+++ b/Private/Configuration.UsersPerServicePlan.ps1
@@ -1,8 +1,8 @@
-$Script:UsersPerServicePlan = [ordered] @{
+﻿$Script:UsersPerServicePlan = [ordered] @{
     Name       = 'Azure Active Directory Users Per Service Plan'
     Enabled    = $true
     Execute    = {
-        Get-MyUser -PerServicePlan
+        Get-MyUser -PerServicePlan -IncludeSignInActivity
     }
     Processing = {
 
@@ -31,7 +31,10 @@ $Script:UsersPerServicePlan = [ordered] @{
             'ManagerUserPrincipalName', 'ManagerIsSynchronized', 'HasManager', 'LastPasswordChangeDateTime',
             'LastPasswordChangeDays', 'IsSynchronized', 'LastSynchronized', 'LastSynchronizedDays',
             'OnPremisesDistinguishedName', 'LastSignInDateTime', 'LastSignInDaysAgo',
-            'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo', 'NeverSignedIn',
+            'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo',
+            'LastSuccessfulSignInDateTime', 'LastSuccessfulSignInDaysAgo', 'NeverSignedIn',
+            'NeverSuccessfullySignedIn', 'SignInPattern',
+            'SignInActivityRequested', 'SignInActivityAvailable',
             'DeletedServicePlans'
         )
 
@@ -199,7 +202,10 @@ $Script:UsersPerServicePlan = [ordered] @{
                 'ManagerUserPrincipalName', 'ManagerIsSynchronized', 'HasManager', 'LastPasswordChangeDateTime',
                 'LastPasswordChangeDays', 'IsSynchronized', 'LastSynchronized', 'LastSynchronizedDays',
                 'OnPremisesDistinguishedName', 'LastSignInDateTime', 'LastSignInDaysAgo',
-                'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo', 'NeverSignedIn',
+                'LastNonInteractiveSignInDateTime', 'LastNonInteractiveSignInDaysAgo',
+                'LastSuccessfulSignInDateTime', 'LastSuccessfulSignInDaysAgo', 'NeverSignedIn',
+                'NeverSuccessfullySignedIn', 'SignInPattern',
+                'SignInActivityRequested', 'SignInActivityAvailable',
                 'DeletedServicePlans'
             )
 

--- a/Private/Get-GraphEssentialsUsers.ps1
+++ b/Private/Get-GraphEssentialsUsers.ps1
@@ -1,0 +1,43 @@
+function Get-GraphEssentialsUsers {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable] $Query,
+        [Parameter(Mandatory)][string] $CommandName,
+        [switch] $IncludeSignInActivity
+    )
+
+    $Request = @{}
+    foreach ($Entry in $Query.GetEnumerator()) {
+        $Request[$Entry.Key] = $Entry.Value
+    }
+
+    $Properties = @($Request.Property | Where-Object { $_ -ne 'SignInActivity' })
+    if ($IncludeSignInActivity) {
+        $Properties += 'SignInActivity'
+    }
+    $Request.Property = $Properties
+
+    try {
+        $Users = @(Get-MgUser @Request -ErrorAction Stop)
+        $SignInActivityAvailable = [bool] $IncludeSignInActivity
+    } catch {
+        $GraphErrorMessage = [string] $_.Exception.Message
+        $IsMissingAuditPermission = $IncludeSignInActivity -and
+            $GraphErrorMessage -match 'AuditLog\.Read\.All' -and
+            $GraphErrorMessage -match '(403|Forbidden|permission)'
+        if (-not $IsMissingAuditPermission) {
+            throw
+        }
+
+        $Request.Property = @($Properties | Where-Object { $_ -ne 'SignInActivity' })
+        Write-Warning -Message "$CommandName - AuditLog.Read.All is not available. Retrying without sign-in activity; user and license data will still be returned."
+        $Users = @(Get-MgUser @Request -ErrorAction Stop)
+        $SignInActivityAvailable = $false
+    }
+
+    [PSCustomObject] @{
+        Users                       = $Users
+        SignInActivityRequested     = [bool] $IncludeSignInActivity
+        SignInActivityAvailable     = $SignInActivityAvailable
+    }
+}

--- a/Private/Get-GraphEssentialsUsers.ps1
+++ b/Private/Get-GraphEssentialsUsers.ps1
@@ -1,4 +1,29 @@
 function Get-GraphEssentialsUsers {
+    <#
+    .SYNOPSIS
+    Retrieves Microsoft Graph users with optional sign-in activity.
+
+    .DESCRIPTION
+    Executes a Get-MgUser query and adds SignInActivity only when requested. If Microsoft
+    Graph rejects that optional property because the caller lacks permission, the query is
+    retried without sign-in activity so the remaining user data is still returned.
+
+    .PARAMETER Query
+    Parameters forwarded to Get-MgUser.
+
+    .PARAMETER CommandName
+    Public command name used in diagnostics.
+
+    .PARAMETER IncludeSignInActivity
+    Requests the SignInActivity property. This requires AuditLog.Read.All.
+
+    .EXAMPLE
+    Get-GraphEssentialsUsers -Query @{ All = $true; Property = @('Id') } -CommandName 'Get-MyUser' -IncludeSignInActivity
+
+    .NOTES
+    This internal helper preserves PowerShell 5.1 compatibility and retries only when an
+    explicitly requested sign-in activity query encounters a Graph permission denial.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][hashtable] $Query,
@@ -11,25 +36,35 @@ function Get-GraphEssentialsUsers {
         $Request[$Entry.Key] = $Entry.Value
     }
 
-    $Properties = @($Request.Property | Where-Object { $_ -ne 'SignInActivity' })
-    if ($IncludeSignInActivity) {
-        $Properties += 'SignInActivity'
-    }
+    $PropertiesWithoutSignInActivity = @(
+        foreach ($Property in @($Request.Property)) {
+            if ($Property -ne 'SignInActivity') {
+                $Property
+            }
+        }
+    )
+    $Properties = @(
+        $PropertiesWithoutSignInActivity
+        if ($IncludeSignInActivity) {
+            'SignInActivity'
+        }
+    )
     $Request.Property = $Properties
 
     try {
         $Users = @(Get-MgUser @Request -ErrorAction Stop)
         $SignInActivityAvailable = [bool] $IncludeSignInActivity
     } catch {
-        $GraphErrorMessage = [string] $_.Exception.Message
+        $GraphError = $_ | Get-GraphEssentialsErrorDetails -FunctionName $CommandName
         $IsMissingAuditPermission = $IncludeSignInActivity -and
-            $GraphErrorMessage -match 'AuditLog\.Read\.All' -and
-            $GraphErrorMessage -match '(403|Forbidden|permission)'
+            ($GraphError.IsPermissionDenied -or
+            $GraphError.StatusCode -eq 403 -or
+            $GraphError.Code -match '(?i)Authorization_RequestDenied|accessDenied|Forbidden')
         if (-not $IsMissingAuditPermission) {
             throw
         }
 
-        $Request.Property = @($Properties | Where-Object { $_ -ne 'SignInActivity' })
+        $Request.Property = $PropertiesWithoutSignInActivity
         Write-Warning -Message "$CommandName - AuditLog.Read.All is not available. Retrying without sign-in activity; user and license data will still be returned."
         $Users = @(Get-MgUser @Request -ErrorAction Stop)
         $SignInActivityAvailable = $false

--- a/Public/Get-MyGuest.ps1
+++ b/Public/Get-MyGuest.ps1
@@ -13,19 +13,27 @@ function Get-MyGuest {
     Get-MyGuest
     Returns guest and external users in the tenant.
 
+    .PARAMETER IncludeSignInActivity
+    Requests sign-in activity from Microsoft Graph. This is opt-in because it requires
+    AuditLog.Read.All. If that permission is unavailable, the command retries without
+    sign-in activity while retaining guest and license data.
+
     .NOTES
     This function requires the Microsoft.Graph.Users and Microsoft.Graph.Identity modules
     with appropriate permissions. Typically requires User.Read.All permissions.
+    Sign-in activity is not requested by default.
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [switch] $IncludeSignInActivity
+    )
 
     $Today = Get-Date
     $Properties = @(
         'AccountEnabled', 'AssignedPlans', 'CompanyName', 'CreatedDateTime', 'CreationType',
         'DisplayName', 'ExternalUserState', 'ExternalUserStateChangeDateTime', 'Id',
         'LicenseAssignmentStates', 'Mail', 'OnPremisesSyncEnabled', 'OtherMails',
-        'SignInActivity', 'UserPrincipalName', 'UserType'
+        'UserPrincipalName', 'UserType'
     )
 
     Write-Verbose -Message 'Get-MyGuest - Getting list of licenses'
@@ -47,7 +55,8 @@ function Get-MyGuest {
 
     Write-Verbose -Message 'Get-MyGuest - Getting list of guest and external users'
     $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
-    $AllGuests = Get-MgUser @getMgUserSplat
+    $GuestQuery = Get-GraphEssentialsUsers -Query $getMgUserSplat -CommandName 'Get-MyGuest' -IncludeSignInActivity:$IncludeSignInActivity
+    $AllGuests = @($GuestQuery.Users)
     $EndTime = Stop-TimeLog -Time $StartTime -Option OneLiner
     Write-Verbose -Message "Get-MyGuest - Got $($AllGuests.Count) guest users in $EndTime. Now processing them."
 
@@ -188,6 +197,8 @@ function Get-MyGuest {
             NeverSignedIn                     = $NeverSignedIn
             NeverSuccessfullySignedIn         = $NeverSuccessfullySignedIn
             SignInPattern                     = $SignInPattern
+            SignInActivityRequested           = $GuestQuery.SignInActivityRequested
+            SignInActivityAvailable           = $GuestQuery.SignInActivityAvailable
             CreationType                      = $Guest.CreationType
             CompanyName                       = $Guest.CompanyName
             IsSynchronized                    = if ($Guest.OnPremisesSyncEnabled) { $Guest.OnPremisesSyncEnabled } else { $null }

--- a/Public/Get-MyUser.ps1
+++ b/Public/Get-MyUser.ps1
@@ -14,6 +14,11 @@ function Get-MyUser {
     .PARAMETER PerServicePlan
     When specified, organizes user information by service plan instead of by user.
 
+    .PARAMETER IncludeSignInActivity
+    Requests sign-in activity from Microsoft Graph. This is opt-in because it requires
+    AuditLog.Read.All. If that permission is unavailable, the command retries without
+    sign-in activity while retaining user and license data.
+
     .EXAMPLE
     Get-MyUser
     Returns detailed information about all users in the tenant.
@@ -29,12 +34,14 @@ function Get-MyUser {
     .NOTES
     This function requires the Microsoft.Graph.Users and Microsoft.Graph.Identity modules
     with appropriate permissions. Typically requires User.Read.All permissions.
-    Sign-in activity fields may require additional audit-related permissions.
+    Sign-in activity is not requested by default. Use IncludeSignInActivity when those fields
+    are needed and AuditLog.Read.All is available.
     #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
         [Parameter(ParameterSetName = 'PerLicense')][switch] $PerLicense,
-        [Parameter(ParameterSetName = 'PerServicePlan')][switch] $PerServicePlan
+        [Parameter(ParameterSetName = 'PerServicePlan')][switch] $PerServicePlan,
+        [switch] $IncludeSignInActivity
     )
 
     $Today = Get-Date
@@ -42,7 +49,7 @@ function Get-MyUser {
         'LicenseAssignmentStates', 'AccountEnabled', 'AssignedLicenses', 'AssignedPlans', 'CreatedDateTime',
         'DisplayName', 'Id', 'GivenName', 'SurName', 'JobTitle', 'LastPasswordChangeDateTime', 'Mail',
         'OnPremisesLastSyncDateTime', 'OnPremisesSyncEnabled', 'OnPremisesDistinguishedName',
-        'SignInActivity', 'UserPrincipalName', 'UserType'
+        'UserPrincipalName', 'UserType'
     )
 
     Write-Verbose -Message 'Get-MyUser - Getting list of licenses'
@@ -57,7 +64,10 @@ function Get-MyUser {
 
     Write-Verbose -Message 'Get-MyUser - Getting list of all users'
     $StartTime = [System.Diagnostics.Stopwatch]::StartNew()
-    $AllUsers = Get-MgUser @getMgUserSplat -ExpandProperty Manager
+    $getMgUserSplat.ExpandProperty = 'Manager'
+    $UserQuery = Get-GraphEssentialsUsers -Query $getMgUserSplat -CommandName 'Get-MyUser' -IncludeSignInActivity:$IncludeSignInActivity
+    $AllUsers = @($UserQuery.Users)
+    $SignInActivityAvailable = $UserQuery.SignInActivityAvailable
     $EndTime = Stop-TimeLog -Time $StartTime -Option OneLiner
     Write-Verbose -Message "Get-MyUser - Got $($AllUsers.Count) users in $EndTime. Now processing them."
 
@@ -165,6 +175,8 @@ function Get-MyUser {
             NeverSignedIn                    = $NeverSignedIn
             NeverSuccessfullySignedIn        = $NeverSuccessfullySignedIn
             SignInPattern                    = $SignInPattern
+            SignInActivityRequested          = $UserQuery.SignInActivityRequested
+            SignInActivityAvailable          = $SignInActivityAvailable
         }
         $ResolvedLicenses = @(Resolve-GraphEssentialsUserLicenseAssignments -User $User -LicenseLookup $AllLicenses['Licenses'])
 

--- a/Tests/Get-MyGuest.Tests.ps1
+++ b/Tests/Get-MyGuest.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsErrorDetails.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsUsers.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyGuest.ps1')
 

--- a/Tests/Get-MyGuest.Tests.ps1
+++ b/Tests/Get-MyGuest.Tests.ps1
@@ -1,9 +1,16 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsUsers.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyGuest.ps1')
 
     function Get-MyLicense {}
     function Get-MyUserRolesAndLicensesLookup {}
-    function Get-MgUser {}
+    function Get-MgUser {
+        param(
+            [switch] $All,
+            [string] $Filter,
+            [string[]] $Property
+        )
+    }
     function Stop-TimeLog {}
 }
 
@@ -53,11 +60,49 @@ Describe 'Get-MyGuest' {
     }
 
     It 'does not mark successful-only guests as never signed in' {
-        $guests = @(Get-MyGuest)
+        $guests = @(Get-MyGuest -IncludeSignInActivity)
 
         $guests.Count | Should -Be 1
         $guests[0].SignInPattern | Should -Be 'Successful sign-in only'
         $guests[0].NeverSignedIn | Should -BeFalse
         $guests[0].NeverSuccessfullySignedIn | Should -BeFalse
+    }
+
+    It 'does not request sign-in activity by default' {
+        $guests = @(Get-MyGuest)
+
+        $guests[0].SignInActivityRequested | Should -BeFalse
+        $guests[0].SignInActivityAvailable | Should -BeFalse
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -notcontains 'SignInActivity' }
+    }
+
+    It 'retains guests when requested sign-in activity lacks AuditLog.Read.All permission' {
+        $script:GuestGraphCall = 0
+        Mock Get-MgUser {
+            $script:GuestGraphCall++
+            if ($script:GuestGraphCall -eq 1) {
+                throw 'Get-MgUser_List: The principal does not have required Microsoft Graph permission(s): AuditLog.Read.All. Status: 403 (Forbidden)'
+            }
+
+            [PSCustomObject] @{
+                DisplayName             = 'Guest One'
+                Id                      = 'guest-1'
+                UserPrincipalName       = 'guest.one#EXT#@contoso.onmicrosoft.com'
+                Mail                    = 'guest.one@example.com'
+                OtherMails              = @()
+                UserType                = 'Guest'
+                AccountEnabled          = $true
+                LicenseAssignmentStates = @()
+                AssignedPlans           = @()
+            }
+        }
+
+        $guests = @(Get-MyGuest -IncludeSignInActivity -WarningAction SilentlyContinue)
+
+        $guests.Count | Should -Be 1
+        $guests[0].SignInActivityRequested | Should -BeTrue
+        $guests[0].SignInActivityAvailable | Should -BeFalse
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -contains 'SignInActivity' }
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -notcontains 'SignInActivity' }
     }
 }

--- a/Tests/Get-MyUser.Tests.ps1
+++ b/Tests/Get-MyUser.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsErrorDetails.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsUsers.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Resolve-GraphEssentialsUserLicenseAssignments.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyUser.ps1')
@@ -128,6 +129,38 @@ Describe 'Get-MyUser license projection' {
             $script:GraphUserCall++
             if ($script:GraphUserCall -eq 1) {
                 throw 'Get-MgUser_List: The principal does not have required Microsoft Graph permission(s): AuditLog.Read.All. Status: 403 (Forbidden)'
+            }
+
+            [PSCustomObject] @{
+                AccountEnabled              = $true
+                AssignedLicenses            = @([PSCustomObject] @{ SkuId = $script:SkuId })
+                AssignedPlans               = @()
+                DisplayName                 = 'Licensed User'
+                Id                          = 'user-1'
+                LicenseAssignmentStates     = @()
+                Mail                        = 'licensed@contoso.com'
+                Manager                     = $null
+                OnPremisesSyncEnabled       = $null
+                UserPrincipalName           = 'licensed@contoso.com'
+                UserType                    = 'Member'
+            }
+        }
+
+        $result = Get-MyUser -IncludeSignInActivity -WarningAction SilentlyContinue
+
+        $result.HasLicenses | Should -BeTrue
+        $result.SignInActivityRequested | Should -BeTrue
+        $result.SignInActivityAvailable | Should -BeFalse
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -contains 'SignInActivity' }
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -notcontains 'SignInActivity' }
+    }
+
+    It 'retries without sign-in activity for a generic Graph permission denial' {
+        $script:GraphUserCall = 0
+        Mock Get-MgUser {
+            $script:GraphUserCall++
+            if ($script:GraphUserCall -eq 1) {
+                throw 'Authorization_RequestDenied: Insufficient privileges to complete the operation. Status: 403 (Forbidden)'
             }
 
             [PSCustomObject] @{

--- a/Tests/Get-MyUser.Tests.ps1
+++ b/Tests/Get-MyUser.Tests.ps1
@@ -1,4 +1,5 @@
 BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Private\Get-GraphEssentialsUsers.ps1')
     . (Join-Path $PSScriptRoot '..\Private\Resolve-GraphEssentialsUserLicenseAssignments.ps1')
     . (Join-Path $PSScriptRoot '..\Public\Get-MyUser.ps1')
 
@@ -111,5 +112,53 @@ Describe 'Get-MyUser license projection' {
         $result = Get-MyUser -PerLicense
 
         $result.'Microsoft 365 E3' | Should -Contain 'Assigned'
+    }
+
+    It 'does not request sign-in activity by default' {
+        $result = Get-MyUser
+
+        $result.SignInActivityRequested | Should -BeFalse
+        $result.SignInActivityAvailable | Should -BeFalse
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -notcontains 'SignInActivity' }
+    }
+
+    It 'retries without sign-in activity when explicitly requested but AuditLog.Read.All is unavailable' {
+        $script:GraphUserCall = 0
+        Mock Get-MgUser {
+            $script:GraphUserCall++
+            if ($script:GraphUserCall -eq 1) {
+                throw 'Get-MgUser_List: The principal does not have required Microsoft Graph permission(s): AuditLog.Read.All. Status: 403 (Forbidden)'
+            }
+
+            [PSCustomObject] @{
+                AccountEnabled              = $true
+                AssignedLicenses            = @([PSCustomObject] @{ SkuId = $script:SkuId })
+                AssignedPlans               = @()
+                DisplayName                 = 'Licensed User'
+                Id                          = 'user-1'
+                LicenseAssignmentStates     = @()
+                Mail                        = 'licensed@contoso.com'
+                Manager                     = $null
+                OnPremisesSyncEnabled       = $null
+                UserPrincipalName           = 'licensed@contoso.com'
+                UserType                    = 'Member'
+            }
+        }
+
+        $result = Get-MyUser -IncludeSignInActivity -WarningAction SilentlyContinue
+
+        $result.HasLicenses | Should -BeTrue
+        $result.SignInActivityRequested | Should -BeTrue
+        $result.SignInActivityAvailable | Should -BeFalse
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -contains 'SignInActivity' }
+        Should -Invoke Get-MgUser -Times 1 -Exactly -ParameterFilter { $Property -notcontains 'SignInActivity' }
+    }
+
+    It 'does not retry unrelated Graph failures' {
+        Mock Get-MgUser { throw 'Service unavailable' }
+
+        { Get-MyUser -IncludeSignInActivity } | Should -Throw '*Service unavailable*'
+
+        Should -Invoke Get-MgUser -Times 1 -Exactly
     }
 }

--- a/Tests/SignInActivityConsumerContract.Tests.ps1
+++ b/Tests/SignInActivityConsumerContract.Tests.ps1
@@ -1,0 +1,112 @@
+BeforeAll {
+    function Get-MyUser {
+        param(
+            [switch] $PerLicense,
+            [switch] $PerServicePlan,
+            [switch] $IncludeSignInActivity
+        )
+    }
+
+    function Get-MyGuest {
+        param([switch] $IncludeSignInActivity)
+    }
+
+    . (Join-Path $PSScriptRoot '..\Private\Configuration.Users.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Configuration.UsersPerLicense.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Configuration.UsersPerServicePlan.ps1')
+    . (Join-Path $PSScriptRoot '..\Private\Configuration.Guests.ps1')
+}
+
+Describe 'Sign-in activity consumer contracts' {
+    BeforeEach {
+        Mock Get-MyUser
+        Mock Get-MyGuest
+    }
+
+    It 'keeps the built-in user security report opted in' {
+        & $Script:Users.Execute
+
+        Should -Invoke Get-MyUser -Times 1 -Exactly -ParameterFilter { $IncludeSignInActivity }
+    }
+
+    It 'keeps the built-in per-license report opted in' {
+        & $Script:UsersPerLicense.Execute
+
+        Should -Invoke Get-MyUser -Times 1 -Exactly -ParameterFilter { $PerLicense -and $IncludeSignInActivity }
+    }
+
+    It 'keeps the built-in per-service-plan report opted in' {
+        & $Script:UsersPerServicePlan.Execute
+
+        Should -Invoke Get-MyUser -Times 1 -Exactly -ParameterFilter { $PerServicePlan -and $IncludeSignInActivity }
+    }
+
+    It 'keeps the built-in guest security report opted in' {
+        & $Script:Guests.Execute
+
+        Should -Invoke Get-MyGuest -Times 1 -Exactly -ParameterFilter { $IncludeSignInActivity }
+    }
+
+    It 'does not classify sign-in metadata as licenses' {
+        $Script:Reporting = @{
+            UsersPerLicense = @{
+                Data = @([PSCustomObject]@{
+                        DisplayName                     = 'User One'
+                        Enabled                         = $true
+                        UserType                        = 'Member'
+                        IsSynchronized                  = $true
+                        LastSuccessfulSignInDateTime    = Get-Date
+                        LastSuccessfulSignInDaysAgo     = 1
+                        NeverSuccessfullySignedIn       = $false
+                        SignInPattern                   = 'Interactive only'
+                        SignInActivityRequested         = $true
+                        SignInActivityAvailable         = $true
+                        DifferentLicense                = @()
+                        LicensesErrors                  = @()
+                        'Microsoft 365 E3'              = @('Direct')
+                    })
+            }
+        }
+
+        $summary = & $Script:UsersPerLicense.Summary
+        $names = @($summary.LicenseAssignmentSummary.License)
+
+        $names | Should -Contain 'Microsoft 365 E3'
+        $names | Should -Not -Contain 'LastSuccessfulSignInDateTime'
+        $names | Should -Not -Contain 'LastSuccessfulSignInDaysAgo'
+        $names | Should -Not -Contain 'NeverSuccessfullySignedIn'
+        $names | Should -Not -Contain 'SignInPattern'
+    }
+
+    It 'does not classify sign-in metadata as service plans' {
+        $Script:Reporting = @{
+            UsersPerServicePlan = @{
+                Data = @([PSCustomObject]@{
+                        DisplayName                     = 'User One'
+                        Enabled                         = $true
+                        UserType                        = 'Member'
+                        IsSynchronized                  = $true
+                        LastSignInDaysAgo               = 1
+                        LastSuccessfulSignInDateTime    = Get-Date
+                        LastSuccessfulSignInDaysAgo     = 1
+                        NeverSignedIn                   = $false
+                        NeverSuccessfullySignedIn       = $false
+                        SignInPattern                   = 'Interactive only'
+                        SignInActivityRequested         = $true
+                        SignInActivityAvailable         = $true
+                        DeletedServicePlans             = @()
+                        'Exchange Online'               = 'Assigned'
+                    })
+            }
+        }
+
+        $summary = & $Script:UsersPerServicePlan.Summary
+        $names = @($summary.ServicePlanSummary.ServicePlan)
+
+        $names | Should -Contain 'Exchange Online'
+        $names | Should -Not -Contain 'LastSuccessfulSignInDateTime'
+        $names | Should -Not -Contain 'LastSuccessfulSignInDaysAgo'
+        $names | Should -Not -Contain 'NeverSuccessfullySignedIn'
+        $names | Should -Not -Contain 'SignInPattern'
+    }
+}


### PR DESCRIPTION
## Summary

- makes Microsoft Graph sign-in activity an explicit opt-in for `Get-MyUser` and `Get-MyGuest`
- keeps user, guest, and license collection available without `AuditLog.Read.All`
- recognizes structured and generic Graph permission denials, then retries once without sign-in activity
- keeps the built-in identity security reports explicitly opted in, while preventing activity metadata from being treated as license or service-plan columns
- updates the sign-in example and keeps the touched report configurations compatible with Windows PowerShell 5.1 and PowerShell 7

## Usage

Normal user and license inventory no longer requests audit activity:

```powershell
Get-MyUser
```

Request activity only when the report needs it:

```powershell
Get-MyUser -IncludeSignInActivity
Get-MyGuest -IncludeSignInActivity
```

If `AuditLog.Read.All` is unavailable, explicitly opted-in calls warn and retry without activity instead of losing the complete user/license result.

## Compatibility

The new switch and output availability indicators are additive. Existing direct calls continue to return users and licenses, but sign-in fields are empty unless activity is explicitly requested.